### PR TITLE
Fix mount.vmhgfs symlinks if DESTDIR is used

### DIFF
--- a/open-vm-tools/hgfsmounter/Makefile.am
+++ b/open-vm-tools/hgfsmounter/Makefile.am
@@ -33,14 +33,14 @@ install-exec-hook:
 	mv $(DESTDIR)$(sbindir)/mount.vmhgfs \
 		$(DESTDIR)$(sbindir)/mount_vmhgfs
 	-$(MKDIR_P) $(DESTDIR)/sbin
-	-$(LN_S) $(DESTDIR)$(sbindir)/mount_vmhgfs \
+	-$(LN_S) $(sbindir)/mount_vmhgfs \
 		$(DESTDIR)/sbin/mount_vmhgfs &> /dev/null
 uninstall-hook:
 	rm -f $(DESTDIR)$(sbindir)/mount_vmhgfs
 else
 install-exec-hook:
 	-$(MKDIR_P) $(DESTDIR)/sbin
-	-$(LN_S) $(DESTDIR)$(sbindir)/mount.vmhgfs \
+	-$(LN_S) $(sbindir)/mount.vmhgfs \
 		$(DESTDIR)/sbin/mount.vmhgfs &> /dev/null
 uninstall-hook:
 	rm -f $(DESTDIR)/sbin/mount.vmhgfs


### PR DESCRIPTION
Without this change symlinks in the form of
sbin/mount.vmhgfs -> /build/open-vm-tools-10.0.5-3227872/debian/open-vm-tools/usr/sbin/mount.vmhgfs
are being produced, if DESTDIR was uset while running make install.