### PR TITLE
vmxnet: set trans_start only for kernel < 2.6.31

### DIFF
--- a/open-vm-tools/modules/linux/vmxnet/vmxnet.c
+++ b/open-vm-tools/modules/linux/vmxnet/vmxnet.c
@@ -2465,7 +2465,9 @@ vmxnet_tx(struct sk_buff *skb, struct net_device *dev)
       status = VMXNET_CALL_TRANSMIT;
    }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,31)
    dev->trans_start = jiffies;
+#endif
 
    lp->stats.tx_packets++;
    dd->stats.pktsTransmitted++;


### PR DESCRIPTION
- fixes compiling on kernel 4.7
- based on https://www.virtualbox.org/changeset/61429/vbox

Signed-off-by: Dirk Rettschlag <dirk.rettschlag@gmail.com>