### PR TITLE
add ability to backup VMs with btrfs/overlayfs (docker)

### DIFF
--- a/open-vm-tools/lib/syncDriver/syncDriverPosix.c
+++ b/open-vm-tools/lib/syncDriver/syncDriverPosix.c
@@ -42,6 +42,10 @@ static SyncFreezeFn gBackends[] = {
 };
 
 static const char *gRemoteFSTypes[] = {
+  "overlay",
+   "shm",
+   "tmpfs",
+   "btrfs",
    "autofs",
    "cifs",
    "nfs",


### PR DESCRIPTION
ignore filesystems that can’t use freeze via ioctl
same as nfs etc