### PR TITLE
Report SLES12-SAP guest OS as SLES12

### DIFF
--- a/open-vm-tools/lib/misc/hostinfoPosix.c
+++ b/open-vm-tools/lib/misc/hostinfoPosix.c
@@ -534,6 +534,7 @@ HostinfoGetOSShortName(char *distro,         // IN: full distro name
    } else if (strstr(distroLower, "suse")) {
       if (strstr(distroLower, "enterprise")) {
          if (strstr(distroLower, "server 12") ||
+             strstr(distroLower, "server for sap applications 12") ||
              strstr(distroLower, "desktop 12")) {
             Str_Strcpy(distroShort, STR_OS_SLES_12, distroShortSize);
          } else if (strstr(distroLower, "server 11") ||


### PR DESCRIPTION
On SLES12-SP1-SAP the "lsb_release -sd" command returns the string
"SUSE Linux Enterprise Server for SAP Applications 12 SP1".
Parsing in HostinfoGetOSShortName() detects the sub-strings "suse"
and "enterprise" but not "server 12". STR_OS_SLES is returned
resulting in displaying of "SUSE Linux Enterprise 8/9" in the
summary screen of the vSphere client. This is wrong.

So search for the sub-string "server for sap applications 12" and
return STR_OS_SLES_12 there. SLES11-SAP is not affected.