### PR TITLE
Fix the build on FreeBSD 12.0-CURRENT.

### DIFF
--- a/open-vm-tools/modules/freebsd/vmmemctl/os.c
+++ b/open-vm-tools/modules/freebsd/vmmemctl/os.c
@@ -847,7 +847,7 @@ vmmemctl_sysctl(SYSCTL_HANDLER_ARGS)
 static void
 vmmemctl_init_sysctl(void)
 {
-   oid =  sysctl_add_oid(NULL, SYSCTL_STATIC_CHILDREN(_vm), OID_AUTO,
+   oid =  SYSCTL_ADD_OID(NULL, SYSCTL_STATIC_CHILDREN(_vm), OID_AUTO,
                          BALLOON_NAME, CTLTYPE_STRING | CTLFLAG_RD,
                          0, 0, vmmemctl_sysctl, "A",
                          BALLOON_NAME_VERBOSE);


### PR DESCRIPTION
On FreeBSD 12.0-CURRENT we've extended the sysctl_add_oid() function to
include an additional argument: an aggregation label. This doesn't tend
to be problematic, because (almost) all users of these interfaces use of
the recommended macro SYSCTL_ADD_OID(), which didn't get modified.

Fix up this piece of code to make use of this macro as well, so that it
builds on all (supported) versions of FreeBSD.