### PR TITLE
Trap SIGBUS while doing port probe

### DIFF
--- a/open-vm-tools/lib/vmCheck/vmcheck.c
+++ b/open-vm-tools/lib/vmCheck/vmcheck.c
@@ -134,6 +134,7 @@ VmCheckSafe(SafeCheckFn checkFn)
 #else
    do {
       int signals[] = {
+         SIGBUS,
          SIGILL,
          SIGSEGV,
       };


### PR DESCRIPTION
On FreeBSD a SIGBUS is delivered when accessing port that is not accessible,
which is the case when running vmware-vmcheck on bare metal system.