### PR TITLE
Chase FreeBSD INO64 ABI change

### DIFF
--- a/open-vm-tools/lib/hgfsServer/hgfsServerLinux.c
+++ b/open-vm-tools/lib/hgfsServer/hgfsServerLinux.c
@@ -178,6 +178,12 @@ getdents_linux(unsigned int fd,
 #   endif
 }
 #      define getdents getdents_linux
+#elif defined(__FreeBSD__) && defined(__INO64)
+#define getdents(fd, dirp, count)                                             \
+({                                                                            \
+   off_t basep;                                                                \
+   getdirentries(fd, dirp, count, &basep);                                    \
+})
 #elif defined(__FreeBSD__)
 #define getdents(fd, dirp, count)                                             \
 ({                                                                            \


### PR DESCRIPTION
The following commit to FreeBSD:

  r318736 | kib | 2017-05-23 04:29:05 -0500 (Tue, 23 May 2017) | 45 lines

  Commit the 64-bit inode project.

  Extend the ino_t, dev_t, nlink_t types to 64-bit ints.  Modify
  struct dirent layout to add d_off, increase the size of d_fileno
  to 64-bits, increase the size of d_namlen to 16-bits, and change
  the required alignment.  Increase struct statfs f_mntfromname[] and
  f_mntonname[] array length MNAMELEN to 1024.

  ABI breakage is mitigated by providing compatibility using versioned
  symbols, ingenious use of the existing padding in structures, and
  by employing other tricks.  Unfortunately, not everything can be
  fixed, especially outside the base system.  For instance, third-party
  APIs which pass struct stat around are broken in backward and
  forward incompatible ways.

changed the interface for getdirentries()

The fix chases that change and changes the define for the macro
for getdents conditionally based on whether or not the version
of FreeBSD we are compiling for has the 64 bit inode commit or not.

Aa a side affect this fixes compilation of open-vm-tools on
i386 FreeBSD 12-CURRENT after the 64 bit inode commit.