### PR TITLE
Restrict udev rules to disk devices only.

### DIFF
--- a/open-vm-tools/udev/99-vmware-scsi-udev.rules
+++ b/open-vm-tools/udev/99-vmware-scsi-udev.rules
@@ -1,3 +1,3 @@
-ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*" , ATTRS{model}=="Virtual disk*", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/device/timeout'"
-ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*" , ATTRS{model}=="VMware Virtual S", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/device/timeout'"
+ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*" , ATTRS{model}=="Virtual disk*", ENV{DEVTYPE}=="disk", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/device/timeout'"
+ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*" , ATTRS{model}=="VMware Virtual S", ENV{DEVTYPE}=="disk", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/device/timeout'"
 


### PR DESCRIPTION
To avoid spurious udev errors, restrict udev rules to execute only on valid devices, rather than partitions and other components found in sysfs.

Sample spurious messages (generated while setting device timeout) on invalid devices are as follows:

Oct 06 09:59:16 nts109 systemd-udevd[613]: Process '/bin/sh -c 'echo 180 >/sys$DEVPATH/device/timeout'' failed with exit code 1.
Oct 06 09:59:17 nts109 systemd-udevd[743]: Process '/bin/sh -c 'echo 180 >/sys$DEVPATH/device/timeout'' failed with exit code 1.
Oct 06 09:59:17 nts109 systemd-udevd[686]: Process '/bin/sh -c 'echo 180 >/sys$DEVPATH/device/timeout'' failed with exit code 1.