### PR TITLE
Ingore ENXIO errors with SyncDriver

### DIFF
--- a/open-vm-tools/lib/syncDriver/syncDriverLinux.c
+++ b/open-vm-tools/lib/syncDriver/syncDriverLinux.c
@@ -195,6 +195,14 @@ LinuxDriver_Freeze(const GSList *paths,
             Debug(LGPFX "cannot access mounted directory '%s'.\n", path);
             continue;
 
+         case ENXIO:
+            /*
+             * A bind-mounted file (like /dev/log bind mounted for a chrooted
+             * application) gives back ENXIO (6). Just ignore.
+             */
+            Debug(LGPFX "No such device or address error (ENXIO) while opening path '%s'.\n", path);
+            continue;
+
          case EIO:
             /*
              * A mounted HGFS filesystem with the backend disabled will give


### PR DESCRIPTION
A bind mounted file gives a ENXIO (6) error on RHEL7 with `open-vm-tools-10.1.5-3` and fails filesystem freezing with "vmbackup: Error freezing filesystems".

A bind mounted file might be required to, for example, to mount /dev/log for a chrooted application.

Example of /dev/log bind mounted for haproxy on EL7:
```
yum install haproxy
mkdir /var/lib/haproxy/dev
touch /var/lib/haproxy/dev/log
mount -o bind /dev/log /var/lib/haproxy/dev/log
```

Excerpt from debug log from failing filesystem freeze:

```
[Dec 18 14:10:23.730] [    info] [guestinfo] Poll loop for poll-interval disabled.
[Dec 18 14:10:23.732] [   debug] [vmbackup] Submitted backup start task.
[Dec 18 14:10:23.732] [   debug] [vmbackup] *** VmBackupSyncDriverStart
[Dec 18 14:10:23.732] [   debug] [vmsvc] SyncDriver: Skipping remote filesystem, name=systemd-1, mntpt=/proc/sys/fs/binfmt_misc.
[Dec 18 14:10:23.732] [   debug] [vmsvc] SyncDriver: Skipping remote filesystem, name=/etc/auto.home, mntpt=/home..
[Dec 18 14:10:23.732] [   debug] [vmsvc] SyncDriver: Skipping remote filesystem, name=/etc/auto.misc, mntpt=/misc.
[Dec 18 14:10:23.732] [   debug] [vmsvc] SyncDriver: Skipping remote filesystem, name=-hosts, mntpt=/net.
[Dec 18 14:10:23.732] [   debug] [vmsvc] SyncDriver: Calling backend 0.
[Dec 18 14:10:23.732] [   debug] [vmsvc] SyncDriver: Freezing using Linux ioctls...
[Dec 18 14:10:23.732] [   debug] [vmsvc] SyncDriver: opening path '/var/tmp'.
[Dec 18 14:10:23.733] [   debug] [vmsvc] SyncDriver: freezing path '/var/tmp' (fd=8).
[Dec 18 14:10:23.740] [   debug] [vmsvc] SyncDriver: successfully froze '/var/tmp' (fd=8).
[Dec 18 14:10:23.740] [   debug] [vmsvc] SyncDriver: opening path '/tmp'.
[Dec 18 14:10:23.740] [   debug] [vmsvc] SyncDriver: freezing path '/tmp' (fd=10).
[Dec 18 14:10:23.740] [   debug] [vmsvc] SyncDriver: freeze on '/tmp' returned: 16 (Device or resource busy)
[Dec 18 14:10:23.740] [   debug] [vmsvc] SyncDriver: opening path '/var/lib/nfs/rpc_pipefs'.
[Dec 18 14:10:23.740] [   debug] [vmsvc] SyncDriver: freezing path '/var/lib/nfs/rpc_pipefs' (fd=10).
[Dec 18 14:10:23.740] [   debug] [vmsvc] SyncDriver: freeze on '/var/lib/nfs/rpc_pipefs' returned: 95 (Operation not supported)
...
[Dec 18 14:10:23.743] [   debug] [vmsvc] SyncDriver: opening path '/boot'.
[Dec 18 14:10:23.743] [   debug] [vmsvc] SyncDriver: freezing path '/boot' (fd=11).
[Dec 18 14:10:23.743] [   debug] [vmsvc] SyncDriver: successfully froze '/boot' (fd=11).
[Dec 18 14:10:23.743] [   debug] [vmsvc] SyncDriver: opening path '/var/lib/haproxy/dev/log'.
[Dec 18 14:10:23.743] [   debug] [vmsvc] SyncDriver: failed to open '/var/lib/haproxy/dev/log': 6 (No such device or address)
[Dec 18 14:10:23.743] [   debug] [vmsvc] SyncDriver: Thawing fd=11.
[Dec 18 14:10:23.744] [   debug] [vmsvc] SyncDriver: Thawing fd=10.
[Dec 18 14:10:23.744] [   debug] [vmsvc] SyncDriver: Thawing fd=8.
[Dec 18 14:10:23.744] [   debug] [vmsvc] SyncDriver: Closing fd=11.
[Dec 18 14:10:23.745] [   debug] [vmsvc] SyncDriver: Closing fd=10.
[Dec 18 14:10:23.745] [   debug] [vmsvc] SyncDriver: Closing fd=8.
[Dec 18 14:10:23.745] [ warning] [vmbackup] Error freezing filesystems.
[Dec 18 14:10:24.732] [   debug] [vmbackup] *** VmBackupAsyncCallback
[Dec 18 14:10:24.732] [   debug] [vmbackup] *** VmBackupPostProcessCurrentOp
[Dec 18 14:10:24.732] [   debug] [vmbackup] Async request 'VmBackupSyncDriverStart' completed
[Dec 18 14:10:24.732] [   debug] [vmbackup] *** VmBackupSyncDriverReadyForSnapshot
[Dec 18 14:10:24.732] [   debug] [vmbackup] *** VmBackupEnableSync
[Dec 18 14:10:24.732] [    info] [guestinfo] New value for stats-interval is 20s.
[Dec 18 14:10:24.732] [    info] [guestinfo] New value for poll-interval is 30s.
[Dec 18 14:10:24.732] [   debug] [vmsvc] Flushed 41 log messages from cache after resuming log IO.
```