### PR TITLE
Fix compilation error in clang 6.0

### DIFF
--- a/open-vm-tools/services/plugins/vix/vixTools.c
+++ b/open-vm-tools/services/plugins/vix/vixTools.c
@@ -52,6 +52,7 @@
 #include <stdarg.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <limits.h>
 
 #ifdef _WIN32
 #include <WTypes.h>
@@ -7314,7 +7315,7 @@ VixToolsRunScript(VixCommandRequestHeader *requestMsg,  // IN
          goto abort;
       }
    }
-   for (var = 0; var <= 0xFFFFFFFF; var++) {
+   for (var = 0; ; var++) {
       free(tempScriptFilePath);
       tempScriptFilePath = Str_SafeAsprintf(NULL,
                                             "%s"DIRSEPS"%s%d%s",
@@ -7356,6 +7357,9 @@ VixToolsRunScript(VixCommandRequestHeader *requestMsg,  // IN
           * deletes it), we should not try 4+ billion times.
           */
          break;
+      }
+      if (var == INT_MAX) {
+          break;
       }
    }
    if (fd < 0) {


### PR DESCRIPTION
In practice also fixes an endless loop.

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=224816

Original author: Dimitry Andric <dim@FreeBSD.org>