### PR TITLE
Use a default buffer size if there is no limit suggested by `sysconf()`

### DIFF
--- a/open-vm-tools/lib/auth/authPosix.c
+++ b/open-vm-tools/lib/auth/authPosix.c
@@ -264,14 +264,19 @@ AuthAllocateToken(void)
 {
    AuthTokenInternal *ati;
    size_t bufSize;
+   long maxSize;
 
    /*
     * We need to get the maximum size buffer needed by getpwuid_r from
     * sysconf. Multiply by 4 to compensate for the conversion to UTF-8
     * by the Posix_Get*_r() wrappers.
     */
-
-   bufSize = (size_t) sysconf(_SC_GETPW_R_SIZE_MAX) * 4;
+   maxSize = sysconf(_SC_GETPW_R_SIZE_MAX);
+   if (maxSize == -1) {
+      /* Use a default size if there is no hard limit suggested by sysconf() */
+      maxSize = 1024;
+   }
+   bufSize = (size_t) maxSize * 4;
 
    ati = Util_SafeMalloc(sizeof *ati + bufSize);
    ati->bufSize = bufSize;

--- a/open-vm-tools/lib/file/fileTempPosix.c
+++ b/open-vm-tools/lib/file/fileTempPosix.c
@@ -204,11 +204,9 @@ FileGetUserName(uid_t uid)  // IN:
    memPoolSize = _PASSWORD_LEN;
 #else
    memPoolSize = sysconf(_SC_GETPW_R_SIZE_MAX);
-
-   if (memPoolSize <= 0) {
-      Warning("%s: sysconf(_SC_GETPW_R_SIZE_MAX) failed.\n", __FUNCTION__);
-
-      return NULL;
+   if (memPoolSize == -1) {
+      /* Use a default size if there is no hard limit suggested by sysconf() */
+      memPoolSize = 1024;
    }
 #endif
 

--- a/open-vm-tools/services/plugins/vix/vixTools.c
+++ b/open-vm-tools/services/plugins/vix/vixTools.c
@@ -10132,6 +10132,7 @@ abort:
    struct passwd *ppwd = &pwd;
    char *buffer = NULL; // a pool of memory for Posix_Getpwnam_r() to use.
    size_t bufferSize;
+   long maxSize;
 
    /*
     * For POSIX systems, look up the uid of 'username', and compare
@@ -10144,7 +10145,12 @@ abort:
     * Multiply by 4 to compensate for the conversion to UTF-8 by
     * the Posix_Getpwnam_r() wrapper.
     */
-   bufferSize = (size_t) sysconf(_SC_GETPW_R_SIZE_MAX) * 4;
+   maxSize = sysconf(_SC_GETPW_R_SIZE_MAX);
+   if (maxSize == -1) {
+      /* Use a default size if there is no hard limit suggested by sysconf() */
+      maxSize = 1024;
+   }
+   bufferSize = (size_t) maxSize * 4;
 
    buffer = Util_SafeMalloc(bufferSize);
 


### PR DESCRIPTION
Note that sysconf(_SC_GETPW_R_SIZE_MAX) may return -1 if there is no
hard limit on the size of the buffer needed to store all the groups
returned.

Fixes issue #236 by avoiding the allocation of (-1 * 4) bytes of memory.