### PR TITLE
Switch from STAILQ to CK_STAILQ in FreeBSD HEAD.

### DIFF
--- a/open-vm-tools/modules/freebsd/vmxnet/net_compat.h
+++ b/open-vm-tools/modules/freebsd/vmxnet/net_compat.h
@@ -37,9 +37,14 @@
 #if __FreeBSD_version < 500016
    #define VXN_IFMULTI_FIRST LIST_FIRST
    #define VXN_IFMULTI_NEXT  LIST_NEXT
-#else /* >= 500016 */
+#else
+#if __FreeBSD_version <= 1200063
    #define VXN_IFMULTI_FIRST TAILQ_FIRST
    #define VXN_IFMULTI_NEXT  TAILQ_NEXT
+#else /* > 1200063 */
+   #define VXN_IFMULTI_FIRST CK_STAILQ_FIRST
+   #define VXN_IFMULTI_NEXT  CK_STAILQ_NEXT
+#endif /* 1200063 */
 #endif /* 500016 */
 
 #if __FreeBSD_version < 500043


### PR DESCRIPTION
CK_STAILQ is safe to traverse in the presence of
concurrent deletion.


FreeBSD HEAD changed queue types as a part of performance work being done by mmacy.

https://svnweb.freebsd.org/base?view=revision&revision=333813

This patch is required for open-vm-tools to build on FreeBSD HEAD after 333813, and has been tested to ensure it doesn't affect FreeBSD 11, 10, or older HEAD.  It's also currently applied to the FreeBSD port of open-vm-tools. 