### PR TITLE
misc: Do not print NULL string into logs

### DIFF
--- a/open-vm-tools/lib/misc/util_misc.c
+++ b/open-vm-tools/lib/misc/util_misc.c
@@ -719,8 +719,8 @@ Util_ExpandString(const char *fileName) // IN  file path to expand
       ASSERT(!freeChunk[i]);
       chunks[i] = expand;
       if (chunks[i] == NULL) {
-	 Log("%s: Cannot allocate memory to expand \"%s\" in \"%s\".\n",
-             __FUNCTION__, expand, fileName);
+	 Log("%s: Cannot allocate memory to expand in \"%s\".\n",
+             __FUNCTION__, fileName);
 	 goto out;
       }
       chunkSize[i] = strlen(expand);


### PR DESCRIPTION
string format %s is getting a NULL pointer for 'expand'
parameter always since the check for chunks[i] == NULL will ensure that
its always null when the Log() API is called

Signed-off-by: Khem Raj <raj.khem@gmail.com>