### PR TITLE
stop systemd-243 udev complaints

### DIFF
--- a/open-vm-tools/udev/99-vmware-scsi-udev.rules
+++ b/open-vm-tools/udev/99-vmware-scsi-udev.rules
@@ -2,6 +2,6 @@
 #
 # This file is part of open-vm-tools
 
-ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*", ATTRS{model}=="Virtual disk*", ENV{DEVTYPE}=="disk", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/device/timeout'"
-ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*", ATTRS{model}=="VMware Virtual S", ENV{DEVTYPE}=="disk", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/device/timeout'"
+ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*", ATTRS{model}=="Virtual disk*", ENV{DEVTYPE}=="disk", RUN+="/bin/sh -c 'echo 180 >/sys$env{DEVPATH}/device/timeout'"
+ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*", ATTRS{model}=="VMware Virtual S", ENV{DEVTYPE}=="disk", RUN+="/bin/sh -c 'echo 180 >/sys$env{DEVPATH}/device/timeout'"
 


### PR DESCRIPTION
Since systemd-243 (commit: https://github.com/systemd/systemd/pull/12905/commits/f85cc54c4bbeca11783efdae4332a2759c8ac64c), the following messages are present in the system log relating to `99-vmware-scsi-udev.rules`:
```
Sep 23 18:48:52 LibreELEC systemd-udevd[378]: Configuration file /usr/lib/udev/rules.d/99-vmware-scsi-udev.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
Sep 23 17:52:24 LibreELEC systemd-udevd[372]: /usr/lib/udev/rules.d/99-vmware-scsi-udev.rules:5 Invalid value "/bin/sh -c 'echo 180 >/sys$DEVPATH/device/timeout'" for RUN (char 27: invalid substitution type), ignoring, but please fix it.
Sep 23 17:52:24 LibreELEC systemd-udevd[372]: /usr/lib/udev/rules.d/99-vmware-scsi-udev.rules:6 Invalid value "/bin/sh -c 'echo 180 >/sys$DEVPATH/device/timeout'" for RUN (char 27: invalid substitution type), ignoring, but please fix it.
```

As [suggested](https://github.com/systemd/systemd/pull/12905#issuecomment-534412042), this PR should fix the `invalid substitution type` warnings.

I'm not sure how to fix the executable permission issue - the file doesn't have the execute permission in the repo (or tarball), so this looks like it is being set during installation.