### PR TITLE
Fix udev warnings

### DIFF
--- a/open-vm-tools/udev/99-vmware-scsi-udev.rules
+++ b/open-vm-tools/udev/99-vmware-scsi-udev.rules
@@ -2,6 +2,6 @@
 #
 # This file is part of open-vm-tools
 
-ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*", ATTRS{model}=="Virtual disk*", ENV{DEVTYPE}=="disk", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/device/timeout'"
-ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*", ATTRS{model}=="VMware Virtual S", ENV{DEVTYPE}=="disk", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/device/timeout'"
+ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*", ATTRS{model}=="Virtual disk*", ENV{DEVTYPE}=="disk", RUN+="/bin/sh -c 'echo 180 >/sys/$devpath/device/timeout'"
+ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*", ATTRS{model}=="VMware Virtual S", ENV{DEVTYPE}=="disk", RUN+="/bin/sh -c 'echo 180 >/sys/$devpath/device/timeout'"
 

--- a/open-vm-tools/udev/Makefile.am
+++ b/open-vm-tools/udev/Makefile.am
@@ -17,5 +17,5 @@
 
 install-data-local:
 	$(INSTALL) -d $(DESTDIR)$(UDEVRULESDIR)
-	$(INSTALL) $(srcdir)/99-vmware-scsi-udev.rules $(DESTDIR)$(UDEVRULESDIR)
+	$(INSTALL) -m 0644 $(srcdir)/99-vmware-scsi-udev.rules $(DESTDIR)$(UDEVRULESDIR)
 


### PR DESCRIPTION
Right now udev logs these 2 warnings in the journal:

```
systemd-udevd[445]: Configuration file /usr/lib/udev/rules.d/99-vmware-scsi-udev.rules is marked executable. Please remove executable permission bits. Proceeding anyway.

systemd-udevd[445]: /usr/lib/udev/rules.d/99-vmware-scsi-udev.rules:5 Invalid value "/bin/sh -c 'echo 180 >/sys$DEVPATH/device/timeout'" for RUN (char 27: invalid substitution type), ignoring, but please fix it.
```

This PR is to eliminate those 2 warnings. 