### PR TITLE
install udev rule without executable bit

### DIFF
--- a/open-vm-tools/udev/99-vmware-scsi-udev.rules
+++ b/open-vm-tools/udev/99-vmware-scsi-udev.rules
@@ -2,6 +2,6 @@
 #
 # This file is part of open-vm-tools
 
-ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*", ATTRS{model}=="Virtual disk*", ENV{DEVTYPE}=="disk", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/device/timeout'"
-ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*", ATTRS{model}=="VMware Virtual S", ENV{DEVTYPE}=="disk", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/device/timeout'"
+ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*", ATTRS{model}=="Virtual disk*", ENV{DEVTYPE}=="disk", RUN+="/bin/sh -c 'echo 180 >/sys$env{DEVPATH}/device/timeout'"
+ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*", ATTRS{model}=="VMware Virtual S", ENV{DEVTYPE}=="disk", RUN+="/bin/sh -c 'echo 180 >/sys$env{DEVPATH}/device/timeout'"
 

--- a/open-vm-tools/udev/Makefile.am
+++ b/open-vm-tools/udev/Makefile.am
@@ -17,5 +17,5 @@
 
 install-data-local:
 	$(INSTALL) -d $(DESTDIR)$(UDEVRULESDIR)
-	$(INSTALL) $(srcdir)/99-vmware-scsi-udev.rules $(DESTDIR)$(UDEVRULESDIR)
+	$(INSTALL_DATA) $(srcdir)/99-vmware-scsi-udev.rules $(DESTDIR)$(UDEVRULESDIR)
 


### PR DESCRIPTION
systemd-udevd reports:

Configuration file /usr/lib/udev/rules.d/99-vmware-scsi-udev.rules is marked executable. Please remove executable permission bits. Proceeding anyway.

This changes the udev rule to be installed as data (and without
executable bit).