### PR TITLE
Fixed linking libDeployPkg

### DIFF
--- a/open-vm-tools/libDeployPkg/Makefile.am
+++ b/open-vm-tools/libDeployPkg/Makefile.am
@@ -25,6 +25,7 @@ AM_CFLAGS += @GLIB2_CPPFLAGS@
 
 libDeployPkg_la_LIBADD =
 libDeployPkg_la_LIBADD += @MSPACK_LIBS@
+libDeployPkg_la_LIBADD += @VMTOOLS_LIBS@
 
 libDeployPkg_la_SOURCES =
 libDeployPkg_la_SOURCES += deployPkgFormat.h


### PR DESCRIPTION
Verifying ELF objects in /usr/src/tmp/open-vm-tools-buildroot (arch=normal,fhs=normal,lfs=relaxed,lint=relaxed,rpath=normal,stack=normal,textrel=normal,unresolved=normal)
verify-elf: ERROR: ./usr/lib64/libDeployPkg.so.0.0.0: undefined symbol: Str_Strcat
verify-elf: ERROR: ./usr/lib64/libDeployPkg.so.0.0.0: undefined symbol: Str_Sprintf
verify-elf: ERROR: ./usr/lib64/libDeployPkg.so.0.0.0: undefined symbol: File_IsDirectory
verify-elf: ERROR: ./usr/lib64/libDeployPkg.so.0.0.0: undefined symbol: RpcChannel_SendOne
verify-elf: ERROR: ./usr/lib64/libDeployPkg.so.0.0.0: undefined symbol: StrUtil_ReplaceAll
verify-elf: ERROR: ./usr/lib64/libDeployPkg.so.0.0.0: undefined symbol: UtilSafeStrdup0
verify-elf: ERROR: ./usr/lib64/libDeployPkg.so.0.0.0: undefined symbol: UtilSafeRealloc0
verify-elf: ERROR: ./usr/lib64/libDeployPkg.so.0.0.0: undefined symbol: UtilSafeMalloc0
verify-elf: ERROR: ./usr/lib64/libDeployPkg.so.0.0.0: undefined symbol: Str_Vsnprintf