### PR TITLE
build: fix propagation of libtirpc flags

### DIFF
--- a/open-vm-tools/tests/testDebug/Makefile.am
+++ b/open-vm-tools/tests/testDebug/Makefile.am
@@ -22,6 +22,7 @@ libtestDebug_la_CPPFLAGS =
 libtestDebug_la_CPPFLAGS += @CUNIT_CPPFLAGS@
 libtestDebug_la_CPPFLAGS += @GOBJECT_CPPFLAGS@
 libtestDebug_la_CPPFLAGS += @PLUGIN_CPPFLAGS@
+libtestDebug_la_CPPFLAGS += @XDR_CPPFLAGS@
 
 libtestDebug_la_LDFLAGS =
 libtestDebug_la_LDFLAGS += @PLUGIN_LDFLAGS@
@@ -30,6 +31,7 @@ libtestDebug_la_LIBADD =
 libtestDebug_la_LIBADD += @CUNIT_LIBS@
 libtestDebug_la_LIBADD += @GOBJECT_LIBS@
 libtestDebug_la_LIBADD += @VMTOOLS_LIBS@
+libtestDebug_la_LIBADD += @XDR_LIBS@
 libtestDebug_la_LIBADD += ../vmrpcdbg/libvmrpcdbg.la
 
 libtestDebug_la_SOURCES =

--- a/open-vm-tools/tests/testPlugin/Makefile.am
+++ b/open-vm-tools/tests/testPlugin/Makefile.am
@@ -22,6 +22,7 @@ libtestPlugin_la_CPPFLAGS =
 libtestPlugin_la_CPPFLAGS += @CUNIT_CPPFLAGS@
 libtestPlugin_la_CPPFLAGS += @GOBJECT_CPPFLAGS@
 libtestPlugin_la_CPPFLAGS += @PLUGIN_CPPFLAGS@
+libtestPlugin_la_CPPFLAGS += @XDR_CPPFLAGS@
 
 libtestPlugin_la_LDFLAGS =
 libtestPlugin_la_LDFLAGS += @PLUGIN_LDFLAGS@

--- a/open-vm-tools/tests/vmrpcdbg/Makefile.am
+++ b/open-vm-tools/tests/vmrpcdbg/Makefile.am
@@ -21,6 +21,7 @@ libvmrpcdbg_la_CPPFLAGS =
 libvmrpcdbg_la_CPPFLAGS += @CUNIT_CPPFLAGS@
 libvmrpcdbg_la_CPPFLAGS += @GMODULE_CPPFLAGS@
 libvmrpcdbg_la_CPPFLAGS += @VMTOOLS_CPPFLAGS@
+libvmrpcdbg_la_CPPFLAGS += @XDR_CPPFLAGS@
 libvmrpcdbg_la_CPPFLAGS += -I$(top_srcdir)/lib/rpcChannel
 
 libvmrpcdbg_la_LDFLAGS =


### PR DESCRIPTION
open-vm-tools already detects libtripc in configure:
  checking for libtirpc (via pkg-config)... yes
  configure: tirpc is needed: yes
  configure: building with libtirpc
And build uses it most of the time:
  ... -DUSE_TIRPC -I/usr/include/tirpc ...
  ... -ltirpc ...

Yet with glibc2.32 finally dropping --enable-obsolete-rpc that finally
removes /usr/include/rpc/rpc.h and such and only leaves the proper
/usr/include/tirpc/rpc/rpc.h around.
This causes several build issues as the libtripc flags are in XDR_
variables which are not present in all places where XDR related headers
are includes.

Add some more of these flags in the places that got flagged by build
fails to fix compilation with glibc >=2.32.

Fixes: #486

Signed-off-by: Christian Ehrhardt <christian.ehrhardt@canonical.com>