### PR TITLE
udev rules: fix value update method

### DIFF
--- a/open-vm-tools/udev/99-vmware-scsi-udev.rules
+++ b/open-vm-tools/udev/99-vmware-scsi-udev.rules
@@ -2,6 +2,6 @@
 #
 # This file is part of open-vm-tools
 
-ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*", ATTRS{model}=="Virtual disk*", ENV{DEVTYPE}=="disk", RUN+="/bin/sh -c 'echo 180 >/sys$env{DEVPATH}/device/timeout'"
-ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*", ATTRS{model}=="VMware Virtual S", ENV{DEVTYPE}=="disk", RUN+="/bin/sh -c 'echo 180 >/sys$env{DEVPATH}/device/timeout'"
+ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*", ATTRS{model}=="Virtual disk*", ENV{DEVTYPE}=="disk", ATTR{device/timeout}="180"
+ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*", ATTRS{model}=="VMware Virtual S", ENV{DEVTYPE}=="disk", ATTR{device/timeout}="180"
 


### PR DESCRIPTION
Redirection for setting sysfs values is not reliable method. In my case it fails to update disk timeout.
`udev` have built-in writing attributes value mechanism.