### PR TITLE
Fix gtk issues using GCC 11 with gtk >= 3.20

### DIFF
--- a/open-vm-tools/lib/include/tracer.hh
+++ b/open-vm-tools/lib/include/tracer.hh
@@ -28,9 +28,7 @@
 
 #include "vm_basic_defs.h"
 
-extern "C" {
 #include "glib.h"
-}
 
 
 #ifdef VMX86_DEVEL

--- a/open-vm-tools/services/plugins/dndcp/copyPasteUIX11.cpp
+++ b/open-vm-tools/services/plugins/dndcp/copyPasteUIX11.cpp
@@ -1666,6 +1666,7 @@ CopyPasteUIX11::FileBlockMonitorThread(void *arg)   // IN
       char buf[sizeof(VMBLOCK_FUSE_READ_RESPONSE)];
       ssize_t size;
       size = read(fd, buf, sizeof(VMBLOCK_FUSE_READ_RESPONSE));
+      (void) size; /* Prevent unused variable warning */
       /*
        * The current thread will block in read function until
        * any other application accesses the file params->fileBlockName

--- a/open-vm-tools/services/plugins/dndcp/dndGuest/dndCPTransportGuestRpc.hpp
+++ b/open-vm-tools/services/plugins/dndcp/dndGuest/dndCPTransportGuestRpc.hpp
@@ -31,13 +31,11 @@
 
 #include "dnd.h"
 
-extern "C" {
 #ifdef VMX86_TOOLS
    #include "vmware/tools/guestrpc.h"
 #else
    #include "guest_rpc.h"
 #endif
-}
 
 #define GUEST_RPC_CMD_STR_DND "dnd.transport"
 #define GUEST_RPC_CMD_STR_CP  "copypaste.transport"

--- a/open-vm-tools/services/plugins/dndcp/dndUIX11.cpp
+++ b/open-vm-tools/services/plugins/dndcp/dndUIX11.cpp
@@ -467,8 +467,13 @@ DnDUIX11::OnSrcDragBegin(const CPClipboard *clip,       // IN
 #ifndef GTK3
    event.device = gdk_device_get_core_pointer();
 #else
+  #if GTK_MINOR_VERSION >= 20
+   GdkSeat* seat = gdk_display_get_default_seat(gdk_window_get_display(event.window));
+   event.device = gdk_seat_get_pointer(seat);
+  #else
    GdkDeviceManager* manager = gdk_display_get_device_manager(gdk_window_get_display(event.window));
    event.device = gdk_device_manager_get_client_pointer(manager);
+  #endif
 #endif
    event.x_root = mOrigin.get_x();
    event.y_root = mOrigin.get_y();

--- a/open-vm-tools/services/plugins/dndcp/dndcp.cpp
+++ b/open-vm-tools/services/plugins/dndcp/dndcp.cpp
@@ -33,9 +33,9 @@
 
 extern "C" {
 #include "vmware/guestrpc/tclodefs.h"
+}
 #include "vmware/tools/plugin.h"
 #include "vmware/tools/utils.h"
-}
 
 #include <string.h>
 #include "copyPasteDnDWrapper.h"


### PR DESCRIPTION
Newer gcc is more strict when detecting issues. To be able to properly
build open-vm-tools, following fixes has to be done:

1) gdk_display_get_device_manager was deprecated and this is properly
   detected by compiler and cause warning.
   Use newer gdk_display_get_default_seat function.

2) Several gtk files can be no longer compiled using extern C and they
   have to be in full C++ code.

3) Return value from read function has to be used otherwise produce
   unused variable warning. Not working with the return value cause
   unused result warning. This can be avoided using dummy retyping
   in case return value is not used.

Signed-off-by: Miroslav Rezanina <mrezanin@redhat.com>