### PR TITLE
vmblock-fuse, vmhgfs-fuse: Add support for libfuse3

### DIFF
--- a/open-vm-tools/configure.ac
+++ b/open-vm-tools/configure.ac
@@ -519,6 +519,7 @@ fi
 #
 # Check for fuse.
 #
+# FUSE_USE_VERSION sets the version of the FUSE API that will be exported.
 AC_VMW_CHECK_LIB([fuse],
                  [FUSE],
                  [fuse],
@@ -526,7 +527,8 @@ AC_VMW_CHECK_LIB([fuse],
                  [],
                  [fuse.h],
                  [fuse_main],
-                 [have_fuse=yes],
+                 [have_fuse=yes;
+                  AC_DEFINE([FUSE_USE_VERSION], 29, [FUSE API version to use.])],
                  [have_fuse=no;
                   AC_MSG_WARN([Fuse is missing, vmblock-fuse/vmhgfs-fuse will be disabled.])])
 

--- a/open-vm-tools/configure.ac
+++ b/open-vm-tools/configure.ac
@@ -519,18 +519,71 @@ fi
 #
 # Check for fuse.
 #
-# FUSE_USE_VERSION sets the version of the FUSE API that will be exported.
-AC_VMW_CHECK_LIB([fuse],
-                 [FUSE],
-                 [fuse],
-                 [],
-                 [],
-                 [fuse.h],
-                 [fuse_main],
-                 [have_fuse=yes;
-                  AC_DEFINE([FUSE_USE_VERSION], 29, [FUSE API version to use.])],
-                 [have_fuse=no;
-                  AC_MSG_WARN([Fuse is missing, vmblock-fuse/vmhgfs-fuse will be disabled.])])
+AC_ARG_WITH([fuse],
+   [AS_HELP_STRING([--without-fuse],
+     [compiles without FUSE support (disables vmblock-fuse/vmhgfs-fuse).])],
+   [with_fuse="$withval"],
+   [with_fuse=auto])
+
+case "$with_fuse" in
+   fuse|2)
+      with_fuse="fuse"
+      ;;
+   fuse3|3)
+      with_fuse="fuse3"
+      ;;
+   auto)
+      ;;
+   *)
+      AC_MSG_FAILURE([--with-fuse was given with an unsupported paramter $with_fuse])
+      ;;
+esac
+
+if test "$with_fuse" = "auto" || test "$with_fuse" = "fuse3"; then
+   #
+   # Check for fuse3.
+   #
+   # FUSE_USE_VERSION sets the version of the FUSE API that will be exported.
+   AC_VMW_CHECK_LIB([fuse3],
+                    [FUSE3],
+                    [fuse3],
+                    [],
+                    [3.10.0],
+                    [fuse3/fuse.h],
+                    [fuse_main],
+                    [have_fuse3=yes;
+                     AC_DEFINE([HAVE_FUSE3], 1, [Define to 1 if using FUSE3.])
+                     AC_DEFINE([FUSE_USE_VERSION], 35, [FUSE API version to use.])],
+                    [have_fuse3=no])
+
+   if test "$have_fuse3" = "no"; then
+      if test "$with_fuse" = "auto"; then
+         AC_MSG_NOTICE([Fuse3 is missing, trying to use older Fuse library.])
+      else
+         AC_MSG_WARN([Fuse3 is missing, vmblock-fuse/vmhgfs-fuse will be disabled.])
+      fi
+   fi
+fi
+
+if test "$with_fuse" = "fuse" ||
+   ( test "$with_fuse" = "auto" && test "$have_fuse3" = "no" ); then
+   #
+   # Check for fuse.
+   #
+   # FUSE_USE_VERSION sets the version of the FUSE API that will be exported.
+   AC_VMW_CHECK_LIB([fuse],
+                    [FUSE],
+                    [fuse],
+                    [],
+                    [],
+                    [fuse.h],
+                    [fuse_main],
+                    [have_fuse=yes;
+                     AC_DEFINE([HAVE_FUSE], 1, [Define to 1 if using FUSE.])
+                     AC_DEFINE([FUSE_USE_VERSION], 29, [FUSE API version to use.])],
+                    [have_fuse=no;
+                     AC_MSG_WARN([Fuse is missing, vmblock-fuse/vmhgfs-fuse will be disabled.])])
+fi
 
 #
 # Check for PAM.
@@ -1478,7 +1531,8 @@ AM_CONDITIONAL(HAVE_XCOMPOSITE, test "$have_xcomposite" = "yes")
 AM_CONDITIONAL(ENABLE_TESTS, test "$have_cunit" = "yes")
 AM_CONDITIONAL(WITH_ROOT_PRIVILEGES, test "$with_root_privileges" = "yes")
 AM_CONDITIONAL(HAVE_DOXYGEN, test "$have_doxygen" = "yes")
-AM_CONDITIONAL(HAVE_FUSE, test "$have_fuse" = "yes")
+AM_CONDITIONAL(HAVE_FUSE, test "$have_fuse" = "yes" || test "$have_fuse3" = "yes")
+AM_CONDITIONAL(HAVE_FUSE3, test "$have_fuse3" = "yes")
 AM_CONDITIONAL(HAVE_GNU_LD, test "$with_gnu_ld" = "yes")
 AM_CONDITIONAL(HAVE_GTKMM, test "$have_x" = "yes" -a \( "$with_gtkmm" = "yes" -o "$with_gtkmm3" = "yes" \) )
 AM_CONDITIONAL(HAVE_PAM, test "$with_pam" = "yes")

--- a/open-vm-tools/vmblock-fuse/Makefile.am
+++ b/open-vm-tools/vmblock-fuse/Makefile.am
@@ -29,12 +29,14 @@ AM_CFLAGS += -D_XOPEN_SOURCE=600
 AM_CFLAGS += -DUSERLEVEL
 AM_CFLAGS += -D_FILE_OFFSET_BITS=64
 AM_CFLAGS += @FUSE_CPPFLAGS@
+AM_CFLAGS += @FUSE3_CPPFLAGS@
 AM_CFLAGS += @GLIB2_CPPFLAGS@
 AM_CFLAGS += -I$(top_srcdir)/modules/shared/vmblock
 AM_CFLAGS += -I$(srcdir)
 
 vmware_vmblock_fuse_LDADD =
 vmware_vmblock_fuse_LDADD += @FUSE_LIBS@
+vmware_vmblock_fuse_LDADD += @FUSE3_LIBS@
 vmware_vmblock_fuse_LDADD += @GLIB2_LIBS@
 
 vmware_vmblock_fuse_SOURCES =

--- a/open-vm-tools/vmblock-fuse/fsops.c
+++ b/open-vm-tools/vmblock-fuse/fsops.c
@@ -765,7 +765,7 @@ VMBlockRelease(const char *path,                   // IN: Must be control file.
  */
 
 void *
-VMBlockInit(void)
+VMBlockInit(struct fuse_conn_info *conn)
 {
    BlockInit();
    return NULL;

--- a/open-vm-tools/vmblock-fuse/fsops.c
+++ b/open-vm-tools/vmblock-fuse/fsops.c
@@ -65,6 +65,14 @@ static vmblockSpecialDirEntry symlinkDirEntry =
 static vmblockSpecialDirEntry notifyDirEntry =
    { NOTIFY_DIR "/*",   S_IFREG | 0444, 1, 0 };
 
+#if HAVE_FUSE3
+#define CALL_FUSE_FILLER(buf, name, stbuf, off, flags) \
+   filler(buf, name, stbuf, off, flags)
+#else
+#define CALL_FUSE_FILLER(buf, name, stbuf, off, flags) \
+   filler(buf, name, stbuf, off)
+#endif
+
 /*
  *-----------------------------------------------------------------------------
  *
@@ -248,9 +256,16 @@ SetTimesToNow(struct stat *statBuf)      // OUT
  *-----------------------------------------------------------------------------
  */
 
+#if HAVE_FUSE3
+int
+VMBlockGetAttr(const char *path,          // IN: File to get attributes of.
+               struct stat *statBuf,      // OUT: Where to put the attributes.
+               struct fuse_file_info *fi) // IN: Ignored
+#else
 int
 VMBlockGetAttr(const char *path,        // IN: File to get attributes of.
                struct stat *statBuf)    // OUT: Where to put the attributes.
+#endif
 {
    vmblockSpecialDirEntry *dirEntry;
    ASSERT(path != NULL);
@@ -362,7 +377,7 @@ ExternalReadDir(const char *blockPath,           // IN:
    errno = 0;
 
    while ((dentry = readdir(dir)) != NULL) {
-      status = filler(buf, dentry->d_name, &statBuf, 0);
+      status = CALL_FUSE_FILLER(buf, dentry->d_name, &statBuf, 0, 0);
       if (status == 1) {
          break;
       }
@@ -408,6 +423,17 @@ ExternalReadDir(const char *blockPath,           // IN:
  *-----------------------------------------------------------------------------
  */
 
+#if HAVE_FUSE3
+int
+VMBlockReadDir(const char *path,                // IN: Directory to read.
+               void *buf,                       // OUT: Where to put directory
+                                                //      listing.
+               fuse_fill_dir_t filler,          // IN: Function to add an entry
+                                                //     to buf.
+               off_t offset,                    // IN: Ignored.
+               struct fuse_file_info *fileInfo, // IN: Ignored.
+               enum fuse_readdir_flags flags)   // IN: Ignored.
+#else
 int
 VMBlockReadDir(const char *path,                // IN: Directory to read.
                void *buf,                       // OUT: Where to put directory
@@ -416,6 +442,7 @@ VMBlockReadDir(const char *path,                // IN: Directory to read.
                                                 //     to buf.
                off_t offset,                    // IN: Ignored.
                struct fuse_file_info *fileInfo) // IN: Ignored.
+#endif
 {
    struct stat fileStat;
    struct stat dirStat;
@@ -433,11 +460,11 @@ VMBlockReadDir(const char *path,                // IN: Directory to read.
    dirStat.st_mode = S_IFDIR;
 
    if (strcmp(path, "/") == 0) {
-      (void)(filler(buf, ".", &dirStat, 0) ||
-             filler(buf, "..", &dirStat, 0) ||
-             filler(buf, VMBLOCK_DEVICE_NAME, &fileStat, 0) ||
-             filler(buf, REDIRECT_DIR_NAME, &dirStat, 0) ||
-             filler(buf, NOTIFY_DIR_NAME, &dirStat, 0));
+      (void)(CALL_FUSE_FILLER(buf, ".", &dirStat, 0, 0) ||
+             CALL_FUSE_FILLER(buf, "..", &dirStat, 0, 0) ||
+             CALL_FUSE_FILLER(buf, VMBLOCK_DEVICE_NAME, &fileStat, 0, 0) ||
+             CALL_FUSE_FILLER(buf, REDIRECT_DIR_NAME, &dirStat, 0, 0) ||
+             CALL_FUSE_FILLER(buf, NOTIFY_DIR_NAME, &dirStat, 0, 0));
       return 0;
    } else if (   (strcmp(path, REDIRECT_DIR) == 0)
               || (strcmp(path, NOTIFY_DIR) == 0)) {
@@ -764,8 +791,14 @@ VMBlockRelease(const char *path,                   // IN: Must be control file.
  *-----------------------------------------------------------------------------
  */
 
+#if HAVE_FUSE3
+void *
+VMBlockInit(struct fuse_conn_info *conn,
+            struct fuse_config *config)
+#else
 void *
 VMBlockInit(struct fuse_conn_info *conn)
+#endif
 {
    BlockInit();
    return NULL;

--- a/open-vm-tools/vmblock-fuse/fsops.h
+++ b/open-vm-tools/vmblock-fuse/fsops.h
@@ -30,13 +30,6 @@
 #ifndef _VMBLOCK_FUSE_H_
 #define _VMBLOCK_FUSE_H_
 
-/*
- * FUSE_USE_VERSION sets the version of the FUSE API that will be exported.
- * Version 25 is the newest version supported by the libfuse in our toolchain
- * as of 2008-07.
- */
-
-#define FUSE_USE_VERSION 25
 #include <fuse.h>
 
 #include "vmblock.h"

--- a/open-vm-tools/vmblock-fuse/fsops.h
+++ b/open-vm-tools/vmblock-fuse/fsops.h
@@ -48,9 +48,17 @@
  */
 
 int VMBlockReadLink(const char *path, char *buf, size_t bufSize);
+#if HAVE_FUSE3
+int VMBlockGetAttr(const char *path, struct stat *statBuf,
+                   struct fuse_file_info *fi);
+int VMBlockReadDir(const char *path, void *buf, fuse_fill_dir_t filler,
+                   off_t offset, struct fuse_file_info *fileInfo,
+                   enum fuse_readdir_flags);
+#else
 int VMBlockGetAttr(const char *path, struct stat *statBuf);
 int VMBlockReadDir(const char *path, void *buf, fuse_fill_dir_t filler,
                    off_t offset, struct fuse_file_info *fileInfo);
+#endif
 int VMBlockOpen(const char *path, struct fuse_file_info *fileInfo);
 int VMBlockWrite(const char *path, const char *buf, size_t size, off_t offset,
                  struct fuse_file_info *fileInfo);

--- a/open-vm-tools/vmblock-fuse/main.c
+++ b/open-vm-tools/vmblock-fuse/main.c
@@ -66,5 +66,5 @@ main(int argc,           // IN
          LOGLEVEL_THRESHOLD = 4;
       }
    }
-   return fuse_main(argc, argv, &vmblockOperations);
+   return fuse_main(argc, argv, &vmblockOperations, NULL);
 }

--- a/open-vm-tools/vmhgfs-fuse/Makefile.am
+++ b/open-vm-tools/vmhgfs-fuse/Makefile.am
@@ -19,10 +19,12 @@ bin_PROGRAMS = vmhgfs-fuse
 
 AM_CFLAGS =
 AM_CFLAGS += @FUSE_CPPFLAGS@
+AM_CFLAGS += @FUSE3_CPPFLAGS@
 AM_CFLAGS += @GLIB2_CPPFLAGS@
 
 vmhgfs_fuse_LDADD =
 vmhgfs_fuse_LDADD += @FUSE_LIBS@
+vmhgfs_fuse_LDADD += @FUSE3_LIBS@
 vmhgfs_fuse_LDADD += @GLIB2_LIBS@
 vmhgfs_fuse_LDADD += @VMTOOLS_LIBS@
 

--- a/open-vm-tools/vmhgfs-fuse/config.c
+++ b/open-vm-tools/vmhgfs-fuse/config.c
@@ -22,6 +22,7 @@
  */
 
 #include "module.h"
+#include <fuse_lowlevel.h>
 #include <sys/utsname.h>
 
 #ifdef VMX86_DEVEL
@@ -76,8 +77,10 @@ const struct fuse_opt vmhgfsOpts[] = {
      VMHGFS_OPT("-l %i",            logLevel, 4),
 #endif
      /* We will change the default value, unless it is specified explicitly. */
+#if !HAVE_FUSE3
      FUSE_OPT_KEY("big_writes",     KEY_BIG_WRITES),
      FUSE_OPT_KEY("nobig_writes",   KEY_NO_BIG_WRITES),
+#endif
 
      FUSE_OPT_KEY("-V",             KEY_VERSION),
      FUSE_OPT_KEY("--version",      KEY_VERSION),
@@ -131,8 +134,13 @@ Usage(char *prog_name)  // IN
 
 #define LIB_MODULEPATH         "/lib/modules"
 #define MODULES_DEP            "modules.dep"
+#if HAVE_FUSE3
+#define FUSER_MOUNT_BIN        "/bin/fusermount3"
+#define FUSER_MOUNT_USR_BIN    "/usr/bin/fusermount3"
+#else
 #define FUSER_MOUNT_BIN        "/bin/fusermount"
 #define FUSER_MOUNT_USR_BIN    "/usr/bin/fusermount"
+#endif
 #define PROC_FILESYSTEMS       "/proc/filesystems"
 #define FUSER_KERNEL_FS        "fuse"
 
@@ -406,7 +414,9 @@ vmhgfsOptProc(void *data,                // IN
               int key,                   // IN
               struct fuse_args *outargs) // OUT
 {
+#if !HAVE_FUSE3
    struct vmhgfsConfig *config = data;
+#endif
 
    switch (key) {
    case FUSE_OPT_KEY_NONOPT:
@@ -434,6 +444,7 @@ vmhgfsOptProc(void *data,                // IN
       }
       return 1;
 
+#if !HAVE_FUSE3
    case KEY_BIG_WRITES:
       config->addBigWrites = TRUE;
       return 0;
@@ -441,11 +452,18 @@ vmhgfsOptProc(void *data,                // IN
    case KEY_NO_BIG_WRITES:
       config->addBigWrites = FALSE;
       return 0;
+#endif
 
    case KEY_HELP:
       Usage(outargs->argv[0]);
+#if HAVE_FUSE3
+      fprintf(stdout, "FUSE options:\n");
+      fuse_cmdline_help();
+      fuse_lib_help(outargs);
+#else
       fuse_opt_add_arg(outargs, "-ho");
       fuse_main(outargs->argc, outargs->argv, NULL, NULL);
+#endif
       exit(1);
 
    case KEY_ENABLED_FUSE: {
@@ -496,8 +514,8 @@ vmhgfsPreprocessArgs(struct fuse_args *outargs)    // IN/OUT
 #ifdef VMX86_DEVEL
    config.logLevel = LOGLEVEL_THRESHOLD;
 #endif
-#ifdef __APPLE__
-   /* osxfuse does not have option 'big_writes'. */
+#if defined(__APPLE__) || HAVE_FUSE3
+   /* osxfuse and fuse3 does not have option 'big_writes'. */
    config.addBigWrites = FALSE;
 #else
    config.addBigWrites = TRUE;

--- a/open-vm-tools/vmhgfs-fuse/dir.c
+++ b/open-vm-tools/vmhgfs-fuse/dir.c
@@ -396,7 +396,11 @@ HgfsReadDirFromReply(uint32 *f_pos,     // IN/OUT: Offset
       st.st_size = attr.size;
       st.st_ino = ino;
       st.st_mode = d_type << 12;
+#if HAVE_FUSE3
+      result = filldir(vfsDirent, escName, &st, 0, 0);
+#else
       result = filldir(vfsDirent, escName, &st, 0);
+#endif
 
       if (result) {
          /*

--- a/open-vm-tools/vmhgfs-fuse/main.c
+++ b/open-vm-tools/vmhgfs-fuse/main.c
@@ -115,9 +115,16 @@ freeAbsPath(char *abspath)  // IN
  *----------------------------------------------------------------------
  */
 
+#if HAVE_FUSE3
+static int
+hgfs_getattr(const char *path,           //IN: path of a file/directory
+             struct stat *stbuf,         //IN/OUT: file/directoy attribute
+             struct fuse_file_info *fi)  //IN/OUT: Unused
+#else
 static int
 hgfs_getattr(const char *path,    //IN: path of a file/directory
              struct stat *stbuf)  //IN/OUT: file/directoy attribute
+#endif
 {
    HgfsHandle fileHandle = HGFS_INVALID_HANDLE;
    HgfsAttrInfo newAttr = {0};
@@ -361,12 +368,22 @@ exit:
  *----------------------------------------------------------------------
  */
 
+#if HAVE_FUSE3
+static int
+hgfs_readdir(const char *path,              //IN: path to a directory
+             void *buf,                     //OUT: buffer to fill the dir entry
+             fuse_fill_dir_t filler,        //IN: function pointer to fill buf
+             off_t offset,                  //IN: offset to read the dir
+             struct fuse_file_info *fi,     //IN: file info set by open call
+             enum fuse_readdir_flags flags) //IN: unused
+#else
 static int
 hgfs_readdir(const char *path,          //IN: path to a directory
              void *buf,                 //OUT: buffer to fill the dir entry
              fuse_fill_dir_t filler,    //IN: function pointer to fill buf
              off_t offset,              //IN: offset to read the dir
              struct fuse_file_info *fi) //IN: file info set by open call
+#endif
 {
    char *abspath = NULL;
    int res = 0;
@@ -598,9 +615,16 @@ exit:
  *----------------------------------------------------------------------
  */
 
+#if HAVE_FUSE3
+static int
+hgfs_rename(const char *from,    //IN: from path name
+            const char *to,      //IN: to path name
+            unsigned int flags)  //IN: unused
+#else
 static int
 hgfs_rename(const char *from,  //IN: from path name
             const char *to)    //IN: to path name
+#endif
 {
    char *absfrom = NULL;
    char *absto = NULL;
@@ -691,9 +715,16 @@ exit:
  *----------------------------------------------------------------------
  */
 
+#if HAVE_FUSE3
+static int
+hgfs_chmod(const char *path,          //IN: path to a file
+           mode_t mode,               //IN: mode to set
+           struct fuse_file_info *fi) //IN/OUT: unused
+#else
 static int
 hgfs_chmod(const char *path,   //IN: path to a file
            mode_t mode)        //IN: mode to set
+#endif
 {
    char *abspath = NULL;
    int res;
@@ -756,10 +787,18 @@ exit:
  *----------------------------------------------------------------------
  */
 
+#if HAVE_FUSE3
+static int
+hgfs_chown(const char *path,           //IN: Path to a file
+           uid_t uid,                  //IN: User id
+           gid_t gid,                  //IN: Group id
+           struct fuse_file_info *fi)  //IN/OUT: unused
+#else
 static int
 hgfs_chown(const char *path,  //IN: Path to a file
            uid_t uid,         //IN: User id
            gid_t gid)         //IN: Group id
+#endif
 {
    HgfsHandle fileHandle = HGFS_INVALID_HANDLE;
    HgfsAttrInfo newAttr = {0};
@@ -819,9 +858,16 @@ exit:
  *----------------------------------------------------------------------
  */
 
+#if HAVE_FUSE3
+static int
+hgfs_truncate(const char *path,           //IN: path to a file
+              off_t size,                 //IN: new size
+              struct fuse_file_info *fi)  //IN/OUT: unused
+#else
 static int
 hgfs_truncate(const char *path,  //IN: path to a file
               off_t size)        //IN: new size
+#endif
 {
    HgfsHandle fileHandle = HGFS_INVALID_HANDLE;
    HgfsAttrInfo newAttr = {0};
@@ -880,9 +926,16 @@ exit:
  *----------------------------------------------------------------------
  */
 
+#if HAVE_FUSE3
+static int
+hgfs_utimens(const char *path,              //IN: path to a file
+             const struct timespec ts[2],   //IN: new time
+             struct fuse_file_info *fi)     //IN/OUT: unused
+#else
 static int
 hgfs_utimens(const char *path,              //IN: path to a file
              const struct timespec ts[2])   //IN: new time
+#endif
 {
    HgfsHandle fileHandle = HGFS_INVALID_HANDLE;
    HgfsAttrInfo newAttr = {0};
@@ -1232,8 +1285,14 @@ exit:
  *----------------------------------------------------------------------
  */
 
+#if HAVE_FUSE3
+static void*
+hgfs_init(struct fuse_conn_info *conn, // IN: unused
+          struct fuse_config *cfg)     // IN/OUT: unused
+#else
 static void*
 hgfs_init(struct fuse_conn_info *conn) // IN: unused
+#endif
 {
    pthread_t purgeCacheThread;
    int dummy;

--- a/open-vm-tools/vmhgfs-fuse/module.h
+++ b/open-vm-tools/vmhgfs-fuse/module.h
@@ -25,8 +25,6 @@
 #ifndef _VMHGFS_FUSE_MODULE_H_
 #define _VMHGFS_FUSE_MODULE_H_
 
-#define FUSE_USE_VERSION 29
-
 #include <sys/types.h>
 #include "hgfsUtil.h"
 #include "vm_assert.h"


### PR DESCRIPTION
libfuse is now deprecated and most distros are switching to use libfuse3
by default, however open-vm-tools doesn't support it.

So add support for compiling using the new library API, there are no
actual changes in behavior a part from function signatures and ignoring
deprecated options.

Autotools logic will prefer libfuse3 by default, or fallback to libfuse
otherwise, unless a specific version is requested using --with-fuse=X

Fixes: #314