### PR TITLE
Make shutdown/reboot commands configurable

### DIFF
--- a/open-vm-tools/configure.ac
+++ b/open-vm-tools/configure.ac
@@ -1445,6 +1445,15 @@ else
     UDEVRULESDIR=""
 fi
 
+AC_ARG_WITH([shutdown-command],
+            [AS_HELP_STRING([--with-shutdown-command=COMMAND],
+                            [command to perform shutdown])],
+            [AC_DEFINE_UNQUOTED([SHUTDOWN_COMMAND], ["$withval"], [])])
+AC_ARG_WITH([reboot-command],
+            [AS_HELP_STRING([--with-reboot-command=COMMAND],
+                            [command to perform reboot])],
+            [AC_DEFINE_UNQUOTED([REBOOT_COMMAND], ["$withval"], [])])
+
 if test "x$enable_resolutionkms" = "xauto"; then
    enable_resolutionkms="no"
 fi

--- a/open-vm-tools/lib/system/systemLinux.c
+++ b/open-vm-tools/lib/system/systemLinux.c
@@ -307,7 +307,9 @@ System_Shutdown(Bool reboot)  // IN: "reboot or shutdown" flag
    char *cmd;
 
    if (reboot) {
-#if defined(sun)
+#if defined(REBOOT_COMMAND)
+      cmd = REBOOT_COMMAND;
+#elif defined(sun)
       cmd = "/usr/sbin/shutdown -g 0 -i 6 -y";
 #elif defined(USERWORLD)
       cmd = "/bin/reboot";
@@ -315,7 +317,9 @@ System_Shutdown(Bool reboot)  // IN: "reboot or shutdown" flag
       cmd = "/sbin/shutdown -r now";
 #endif
    } else {
-#if __FreeBSD__
+#if defined(SHUTDOWN_COMMAND)
+      cmd = SHUTDOWN_COMMAND;
+#elif __FreeBSD__
       cmd = "/sbin/shutdown -p now";
 #elif defined(sun)
       cmd = "/usr/sbin/shutdown -g 0 -i 5 -y";


### PR DESCRIPTION
Some systems, like Alpine Linux, may not use /sbin/shutdown to power off
or reboot. Add configure option so user can set the correct commands.

Fixes https://github.com/vmware/open-vm-tools/issues/235

Signed-off-by: Natanael Copa <ncopa@alpinelinux.org>