### PR TITLE
Multiple fixes and cleanup for FreeBSD

### DIFF
--- a/open-vm-tools/lib/dynxdr/dynxdr.c
+++ b/open-vm-tools/lib/dynxdr/dynxdr.c
@@ -43,9 +43,9 @@ typedef struct DynXdrData {
 } DynXdrData;
 
 /*
- * FreeBSD < 5.0 and Solaris do not declare some parameters as "const".
+ * Solaris do not declare some parameters as "const".
  */
-#if defined(sun) || (defined(__FreeBSD__) && __FreeBSD_version < 500000)
+#if defined(sun)
 #  define DYNXDR_CONST
 #else
 #  define DYNXDR_CONST const

--- a/open-vm-tools/lib/file/filePosix.c
+++ b/open-vm-tools/lib/file/filePosix.c
@@ -749,11 +749,9 @@ File_GetTimes(const char *pathName,        // IN:
 #if defined(__FreeBSD__)
    /*
     * FreeBSD: All supported versions have timestamps with nanosecond
-    * resolution. FreeBSD 5+ has also file creation time.
+    * resolution and also file creation time.
     */
-#   if defined(__FreeBSD_version) && __FreeBSD_version >= 500043
    *createTime     = TimeUtil_UnixTimeToNtTime(statBuf.st_birthtimespec);
-#   endif
    *accessTime     = TimeUtil_UnixTimeToNtTime(statBuf.st_atimespec);
    *writeTime      = TimeUtil_UnixTimeToNtTime(statBuf.st_mtimespec);
    *attrChangeTime = TimeUtil_UnixTimeToNtTime(statBuf.st_ctimespec);

--- a/open-vm-tools/lib/hgfsServer/hgfsServerLinux.c
+++ b/open-vm-tools/lib/hgfsServer/hgfsServerLinux.c
@@ -232,14 +232,11 @@ getdents_apple(DIR *fd,               // IN
 #endif
 
 
-#if defined(sun) || defined(__linux__) || \
-    (defined(__FreeBSD_version) && __FreeBSD_version < 490000)
+#if defined(sun) || defined(__linux__)
 /*
- * Implements futimes(), which was introduced in glibc 2.3.3. FreeBSD 3.2
- * doesn't have it, but 4.9 does. Unfortunately, these early FreeBSD versions
- * don't have /proc/self, so futimes() will simply fail. For now the only
- * caller to futimes() is HgfsServerSetattr which doesn't get invoked at all
- * in the HGFS server which runs in the Tools, so it's OK.
+ * Implements futimes(), which was introduced in glibc 2.3.3.
+ * For now the only caller to futimes() is HgfsServerSetattr which doesn't get
+ * invoked at all in the HGFS server which runs in the Tools, so it's OK.
  */
 #define PROC_SELF_FD "/proc/self/fd/"
 #define STRLEN_OF_MAXINT_AS_STRING 10
@@ -1907,23 +1904,18 @@ HgfsGetCreationTime(const struct stat *stats)
 {
    uint64 creationTime;
    /*
-    * Linux and FreeBSD before v5 doesn't know about creation time; we just use the time
-    * of last data modification for the creation time.
-    * FreeBSD 5+ supprots file creation time.
+    * Linux doesn't know about creation time; we just use the time of last
+    * data modification for the creation time.
     *
     * Using mtime when creation time is unavailable to be consistent with SAMBA.
     */
 
 #ifdef __FreeBSD__
    /*
-    * FreeBSD: All supported versions have timestamps with nanosecond resolution.
-    *          FreeBSD 5+ has also file creation time.
+    * FreeBSD: All supported versions have timestamps with nanosecond resolution
+    *          and also file creation time.
     */
-#   if __IS_FREEBSD_VER__(500043)
    creationTime   = HgfsConvertTimeSpecToNtTime(&stats->st_birthtimespec);
-#   else
-   creationTime   = HgfsConvertTimeSpecToNtTime(&stats->st_mtimespec);
-#   endif
 #elif defined(__linux__)
    /*
     * Linux: Glibc 2.3+ has st_Xtim.  Glibc 2.1/2.2 has st_Xtime/__unusedX on
@@ -2522,8 +2514,8 @@ HgfsStatToFileAttr(struct stat *stats,       // IN: stat information
 
 #ifdef __FreeBSD__
    /*
-    * FreeBSD: All supported versions have timestamps with nanosecond resolution.
-    *          FreeBSD 5+ has also file creation time.
+    * FreeBSD: All supported versions have timestamps with nanosecond resolution
+    *          and also file creation time.
     */
    attr->accessTime     = HgfsConvertTimeSpecToNtTime(&stats->st_atimespec);
    attr->writeTime      = HgfsConvertTimeSpecToNtTime(&stats->st_mtimespec);
@@ -2565,7 +2557,7 @@ HgfsStatToFileAttr(struct stat *stats,       // IN: stat information
        attr->specialPerms, attr->ownerPerms, attr->groupPerms,
        attr->otherPerms, attr->size);
 #ifdef __FreeBSD__
-#   if !defined(VM_X86_64) && !defined(VM_ARM_64) && __FreeBSD_version >= 500043
+#   if !defined(VM_X86_64) && !defined(VM_ARM_64)
 #      define FMTTIMET ""
 #   else
 #      define FMTTIMET "l"

--- a/open-vm-tools/lib/include/vm_basic_defs.h
+++ b/open-vm-tools/lib/include/vm_basic_defs.h
@@ -75,14 +75,6 @@
 #include "includeCheck.h"
 #include "vm_basic_types.h" // For INLINE.
 
-/* Checks for FreeBSD, filtering out VMKERNEL. */
-#if !defined(VMKERNEL) && defined(__FreeBSD__)
-#define __IS_FREEBSD__ 1
-#else
-#define __IS_FREEBSD__ 0
-#endif
-#define __IS_FREEBSD_VER__(ver) (__IS_FREEBSD__ && __FreeBSD_version >= (ver))
-
 /*
  * <stddef.h> provides definitions for:
  *   NULL, offsetof

--- a/open-vm-tools/lib/include/vm_basic_types.h
+++ b/open-vm-tools/lib/include/vm_basic_types.h
@@ -331,12 +331,8 @@ typedef char           Bool;
 #if !defined(USING_AUTOCONF)
 #   if defined(__FreeBSD__) || defined(sun)
 #      ifndef KLD_MODULE
-#         if __FreeBSD_version >= 500043
-#            if !defined(VMKERNEL)
-#               include <inttypes.h>
-#            endif
-#         else
-#            include <sys/inttypes.h>
+#         if !defined(VMKERNEL)
+#            include <inttypes.h>
 #         endif
 #      endif
 #   elif defined __APPLE__

--- a/open-vm-tools/lib/misc/idLinux.c
+++ b/open-vm-tools/lib/misc/idLinux.c
@@ -201,7 +201,7 @@ Id_SetRESUid(uid_t uid,		// IN: new uid
 	     uid_t euid,	// IN: new effective uid
 	     uid_t suid)	// IN: new saved uid
 {
-#if (defined(__FreeBSD__) && __FreeBSD_version >= 500043)
+#if defined(__FreeBSD__)
    return setresuid(uid, euid, suid);
 #elif defined(__linux__)
    if (uid32) {
@@ -281,7 +281,7 @@ Id_SetRESGid(gid_t gid,		// IN: new gid
 	     gid_t egid,	// IN: new effective gid
 	     gid_t sgid)	// IN: new saved gid
 {
-#if (defined(__FreeBSD__) && __FreeBSD_version >= 500043)
+#if defined(__FreeBSD__)
    return setresgid(gid, egid, sgid);
 #elif defined(__linux__)
    if (uid32) {

--- a/open-vm-tools/lib/misc/util_misc.c
+++ b/open-vm-tools/lib/misc/util_misc.c
@@ -304,7 +304,7 @@ Util_CanonicalPathsIdentical(const char *path1,  // IN:
    return (strcmp(path1, path2) == 0);
 #elif defined(_WIN32)
    return (_stricmp(path1, path2) == 0);
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) || defined(__FreeBSD__)
    return (strcasecmp(path1, path2) == 0);
 #else
    NOT_IMPLEMENTED();

--- a/open-vm-tools/lib/string/str.c
+++ b/open-vm-tools/lib/string/str.c
@@ -67,9 +67,7 @@ extern int vasprintf(char **ptr, const char *f, va_list arg);
  * glibc >= 2.2.  I.e., even though they should be able to work on
  * FreeBSD 5.0+ and Solaris 8+, they aren't made available there.
  */
-#   if !(defined(__linux__) ||                                          \
-         (defined(__FreeBSD__) && (__FreeBSD_version >= 500000)) ||     \
-         defined(sun))
+#   if !(defined(__linux__) || defined(__FreeBSD__) || defined(sun))
 extern int vswprintf(wchar_t *wcs, size_t maxlen, const wchar_t *format, va_list args);
 #   endif
 #endif // _WIN32

--- a/open-vm-tools/lib/vmCheck/vmcheck.c
+++ b/open-vm-tools/lib/vmCheck/vmcheck.c
@@ -144,6 +144,9 @@ VmCheckSafe(SafeCheckFn checkFn)
 #else
    do {
       int signals[] = {
+#if defined(__FreeBSD__)
+         SIGBUS,
+#endif
          SIGILL,
          SIGSEGV,
       };

--- a/open-vm-tools/lib/wiper/wiperPosix.c
+++ b/open-vm-tools/lib/wiper/wiperPosix.c
@@ -39,9 +39,9 @@
 # include <sys/ucred.h>
 # include <sys/mount.h>
 # include <fstab.h>
-# if defined(__FreeBSD_version) && __FreeBSD_version >= 500000
+# if defined(__FreeBSD_version)
 #  include <libgen.h>
-# endif /* __FreeBSD_version >= 500000 */
+# endif
 #endif
 #include <unistd.h>
 
@@ -344,27 +344,6 @@ WiperIsDiskDevice(MNTINFO *mnt,         // IN: file system being considered
     * function, as a whole, does not even apply to OS X, so this caveat is
     * only minor.
     */
-#if __FreeBSD_version < 500000
-   /*
-    * Before FreeBSD 5, device nodes had static major/minor numbers.
-    * (FreeBSD 5 included devfs which got rid of this concept.)  So
-    * we'll stat(2) the mount source and test its major numbers
-    * against the values lifted from
-    *   http://www.freebsd.org/cgi/cvsweb.cgi/src/sys/i386/conf/Attic/majors.i386 (rev 1.65)
-    *
-    * Devnode Type      Description                             Major
-    * ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    * block             "Winchester" (IDE, ATA, /dev/wd*)       0
-    * character         "                                       3
-    * block             SCSI "direct access" (/dev/da*)         4
-    * character         "                                       13
-    */
-   int maj = major(s->st_rdev);
-   if ((S_ISBLK(s->st_mode) && ((maj == 0) || (maj == 4))) ||
-       (S_ISCHR(s->st_mode) && ((maj == 3) || (maj == 13)))) {
-      retval = TRUE;
-   }
-#else
    /*
     * Begin by testing whether file system source is really a character
     * device node.  (FreeBSD dropped support for block devices long ago.)
@@ -382,7 +361,6 @@ WiperIsDiskDevice(MNTINFO *mnt,         // IN: file system being considered
    }
 #undef MASK_ATA_DISK
 #undef MASK_SCSI_DISK
-#endif /* __FreeBSD_version */
 
    return retval;
 }

--- a/open-vm-tools/modules/freebsd/shared/compat_freebsd.h
+++ b/open-vm-tools/modules/freebsd/shared/compat_freebsd.h
@@ -53,12 +53,7 @@
  * FreeBSD version 8 and above uses the kproc API instead of the kthread API in its
  * kernel.
  */
-#if __FreeBSD_version > 800001
 #define compat_kthread_create kproc_create
 #define compat_kthread_exit kproc_exit
-#else
-#define compat_kthread_create kthread_create
-#define compat_kthread_exit kthread_exit
-#endif
 
 #endif // __COMPAT_FREEBSD_H__

--- a/open-vm-tools/modules/freebsd/shared/compat_mount.h
+++ b/open-vm-tools/modules/freebsd/shared/compat_mount.h
@@ -44,12 +44,7 @@
 #ifndef __COMPAT_MOUNT_H__
 #   define __COMPAT_MOUNT_H__ 1
 
-#if __FreeBSD_version >= 800011
 #define COMPAT_VFS_STATFS(mp, sbp, threadvar) VFS_STATFS((mp), (sbp))
 #define compat_td curthread
-#else
-#define COMPAT_VFS_STATFS(mp, sbp, threadvar) VFS_STATFS((mp), (sbp), (threadvar))
-#define compat_td td
-#endif
 
 #endif

--- a/open-vm-tools/modules/freebsd/shared/compat_priv.h
+++ b/open-vm-tools/modules/freebsd/shared/compat_priv.h
@@ -44,10 +44,6 @@
 #ifndef __COMPAT_PRIV_H__
 #   define __COMPAT_PRIV_H__ 1
 
-#if __FreeBSD_version >= 800011
 #define compat_priv_check(td, priv) priv_check((td), (priv))
-#else
-#define compat_priv_check(td, priv) suser(td)
-#endif
 
 #endif

--- a/open-vm-tools/modules/freebsd/shared/compat_vop.h
+++ b/open-vm-tools/modules/freebsd/shared/compat_vop.h
@@ -44,7 +44,6 @@
 #ifndef __COMPAT_VOP_H__
 #   define __COMPAT_VOP_H__ 1
 
-#if __FreeBSD_version >= 800011
 #define COMPAT_THREAD_VAR(varname, varval)
 #define COMPAT_VOP_LOCK(vop, flags, threadvar) VOP_LOCK((vop), (flags))
 #if __FreeBSD_version >= 1300074
@@ -57,29 +56,13 @@
 #define compat_vn_lock(vp, flags, threadval) vn_lock((vp), (flags))
 #define compat_accmode_t accmode_t
 #define compat_a_accmode a_accmode
-#else
-#define COMPAT_THREAD_VAR(varname, varval) struct thread *varname = varval
-#define COMPAT_VOP_LOCK(vop, flags, threadvar) VOP_LOCK((vop), (flags), (threadvar))
-#define COMPAT_VOP_UNLOCK(vop, flags, threadvar) VOP_UNLOCK((vop), (flags), (threadvar))
-#define compat_lockstatus(lock, threadvar) lockstatus((lock), (threadvar))
-#define compat_vn_lock(vp, flags, threadval) vn_lock((vp), (flags), (threadval))
-#define compat_lockmgr(lock, flags, randompointerparam, threadval) lockmgr((lock), (flags), (randompointerparam), (threadval))
-#define compat_accmode_t mode_t
-#define compat_a_accmode a_mode
-#endif
 
 /*
  * We use defines rather than typedefs here to avoid causing problems for files that
  * don't have a vnode_if.h available.
  */
-#if __FreeBSD_version >= 700055
-#   define compat_vop_lock_t vop_lock1_t
-#   define compat_vop_lock_args struct vop_lock1_args
-#   define COMPAT_VOP_LOCK_OP_ELEMENT vop_lock1
-#else
-#   define compat_vop_lock_t vop_lock_t
-#   define compat_vop_lock_args struct vop_lock_args
-#   define COMPAT_VOP_LOCK_OP_ELEMENT vop_lock
-#endif
+#define compat_vop_lock_t vop_lock1_t
+#define compat_vop_lock_args struct vop_lock1_args
+#define COMPAT_VOP_LOCK_OP_ELEMENT vop_lock1
 
 #endif

--- a/open-vm-tools/modules/freebsd/vmblock/Makefile
+++ b/open-vm-tools/modules/freebsd/vmblock/Makefile
@@ -46,8 +46,7 @@ SRCS   := $(HEADERS) $(CSRCS)
 
 KMOD    = vmblock
 PROG    = ../$(KMOD).ko
-NOMAN   = t
-NO_MAN  = t
+MK_MAN  = no
 KLDMOD  = t
 
 VMBLOCK := $(MAINSRCROOT)/modules/vmblock

--- a/open-vm-tools/modules/freebsd/vmblock/subr.c
+++ b/open-vm-tools/modules/freebsd/vmblock/subr.c
@@ -389,8 +389,13 @@ VMBlockNodeGet(struct mount *mp,        // IN: VMBlock fs info
       panic("VMBlockNodeGet: Passed a NULL vnlock.\n");
    }
 
-   /* Before FreeBSD 7, insmntque was called by getnewvnode. */
-#if __FreeBSD_version >= 700055
+#if __FreeBSD_version >= 1400051
+   error = insmntque1(vp, mp);
+   if (error != 0) {
+      VMBlockInsMntQueDtr(vp, xp);
+      return error;
+   }
+#else
    error = insmntque1(vp, mp, VMBlockInsMntQueDtr, xp);
    if (error != 0) {
       return error;

--- a/open-vm-tools/modules/freebsd/vmblock/subr.c
+++ b/open-vm-tools/modules/freebsd/vmblock/subr.c
@@ -300,7 +300,6 @@ VMBlockHashRem(struct VMBlockNode *xp)  // IN: node to remove
  *-----------------------------------------------------------------------------
  */
 
-#if __FreeBSD_version >= 700055
 static void
 VMBlockInsMntQueDtr(struct vnode *vp, // IN: node to cleanup
 		    void *xp)         // IN: FS private data
@@ -313,7 +312,6 @@ VMBlockInsMntQueDtr(struct vnode *vp, // IN: node to cleanup
    vgone(vp);
    vput(vp);
 }
-#endif
 
 
 /*

--- a/open-vm-tools/modules/freebsd/vmblock/vfsops.c
+++ b/open-vm-tools/modules/freebsd/vmblock/vfsops.c
@@ -110,12 +110,7 @@ VFS_SET(VMBlockVFSOps, vmblock, VFCF_LOOPBACK);
  */
 
 static int
-#if __FreeBSD_version >= 800011
 VMBlockVFSMount(struct mount *mp)        // IN: mount(2) parameters
-#else
-VMBlockVFSMount(struct mount *mp,        // IN: mount(2) parameters
-                struct thread *td)       // IN: caller's thread context
-#endif
 {
    struct VMBlockMount *xmp;
    struct nameidata nd, *ndp = &nd;
@@ -228,9 +223,6 @@ VMBlockVFSMount(struct mount *mp,        // IN: mount(2) parameters
     */
    MNT_ILOCK(mp);
    mp->mnt_flag |= lowerrootvp->v_mount->mnt_flag & MNT_LOCAL;
-#if __FreeBSD_version >= 600000 && __FreeBSD_version < 1000000
-   mp->mnt_kern_flag |= lowerrootvp->v_mount->mnt_kern_flag & MNTK_MPSAFE;
-#endif
    MNT_IUNLOCK(mp);
 
    mp->mnt_data = (qaddr_t) xmp;
@@ -262,14 +254,8 @@ VMBlockVFSMount(struct mount *mp,        // IN: mount(2) parameters
  */
 
 static int
-#if __FreeBSD_version >= 800011
 VMBlockVFSUnmount(struct mount *mp,    // IN: filesystem to unmount
                   int mntflags)        // IN: unmount(2) flags (ex: MNT_FORCE)
-#else
-VMBlockVFSUnmount(struct mount *mp,    // IN: filesystem to unmount
-                  int mntflags,        // IN: unmount(2) flags (ex: MNT_FORCE)
-                  struct thread *td)   // IN: caller's kernel thread context
-#endif
 {
    struct VMBlockMount *xmp;
    struct vnode *vp;
@@ -350,16 +336,9 @@ VMBlockVFSUnmount(struct mount *mp,    // IN: filesystem to unmount
  */
 
 static int
-#if __FreeBSD_version >= 800011
 VMBlockVFSRoot(struct mount *mp,        // IN: vmblock file system
                int flags,               // IN: lockmgr(9) flags
                struct vnode **vpp)      // OUT: root vnode
-#else
-VMBlockVFSRoot(struct mount *mp,        // IN: vmblock file system
-               int flags,               // IN: lockmgr(9) flags
-               struct vnode **vpp,      // OUT: root vnode
-               struct thread *td)       // IN: caller's thread context
-#endif
 {
    struct vnode *vp;
 
@@ -393,14 +372,8 @@ VMBlockVFSRoot(struct mount *mp,        // IN: vmblock file system
  */
 
 static int
-#if __FreeBSD_version >= 800011
 VMBlockVFSStatFS(struct mount *mp,      // IN: vmblock file system
                  struct statfs *sbp)    // OUT: statfs(2) arg container
-#else
-VMBlockVFSStatFS(struct mount *mp,      // IN: vmblock file system
-                 struct statfs *sbp,    // OUT: statfs(2) arg container
-                 struct thread *td)     // IN: caller's thread context
-#endif
 {
    int error;
    struct statfs mstat;
@@ -448,14 +421,8 @@ VMBlockVFSStatFS(struct mount *mp,      // IN: vmblock file system
  */
 
 static int
-#if __FreeBSD_version >= 800011
 VMBlockVFSSync(struct mount *mp,        // Ignored
                int waitfor)             // Ignored
-#else
-VMBlockVFSSync(struct mount *mp,        // Ignored
-               int waitfor,             // Ignored
-               struct thread *td)       // Ignored
-#endif
 {
    return 0;
 }

--- a/open-vm-tools/modules/freebsd/vmblock/vfsops.c
+++ b/open-vm-tools/modules/freebsd/vmblock/vfsops.c
@@ -166,7 +166,11 @@ VMBlockVFSMount(struct mount *mp)        // IN: mount(2) parameters
     * Find lower node and lock if not already locked.
     */
 
+#if __FreeBSD_version >= 1400043
+   NDINIT(ndp, LOOKUP, FOLLOW|LOCKLEAF, UIO_SYSSPACE, target);
+#else
    NDINIT(ndp, LOOKUP, FOLLOW|LOCKLEAF, UIO_SYSSPACE, target, compat_td);
+#endif
    error = namei(ndp);
    if (error) {
       NDFREE(ndp, 0);

--- a/open-vm-tools/modules/freebsd/vmblock/vfsops.c
+++ b/open-vm-tools/modules/freebsd/vmblock/vfsops.c
@@ -173,7 +173,11 @@ VMBlockVFSMount(struct mount *mp)        // IN: mount(2) parameters
       uma_zfree(VMBlockPathnameZone, pathname);
       return error;
    }
+#ifdef NDF_ONLY_PNBUF
    NDFREE(ndp, NDF_ONLY_PNBUF);
+#else
+   NDFREE_PNBUF(ndp);
+#endif
 
    /*
     * Check multi VMBlock mount to avoid `lock against myself' panic.

--- a/open-vm-tools/modules/freebsd/vmblock/vnops.c
+++ b/open-vm-tools/modules/freebsd/vmblock/vnops.c
@@ -185,9 +185,7 @@
 #include <sys/filedesc.h>
 #include <sys/kdb.h>
 #include "compat_freebsd.h"
-#if __FreeBSD_version >= 700055
 #include <sys/priv.h>
-#endif
 
 #include "vmblock_k.h"
 #include "vmblock.h"
@@ -249,9 +247,7 @@ typedef struct VMBlockIoctlArgs VMBlockIoctlArgs;
 struct vop_vector VMBlockVnodeOps = {
    .vop_bypass =                  VMBlockVopBypass,
    .vop_access =                  VMBlockVopAccess,
-#if __FreeBSD_version >= 900013
    .vop_advlockpurge =            vop_stdadvlockpurge,
-#endif
    .vop_bmap =                    VOP_EOPNOTSUPP,
    .vop_getattr =                 VMBlockVopGetAttr,
    .vop_getwritemount =           VMBlockVopGetWriteMount,
@@ -763,11 +759,7 @@ struct vop_open_args {
        * because none of the existing privs seemed to match very well.
        */
       if ((retval = compat_priv_check(ap->a_td, PRIV_DRIVER)) == 0) {
-#if __FreeBSD_version >= 700055
          fp = ap->a_fp;
-#else
-         fp = ap->a_td->td_proc->p_fd->fd_ofiles[ap->a_fdidx];
-#endif
          fp->f_ops = &VMBlockFileOps;
       }
    } else {
@@ -1357,9 +1349,6 @@ struct vop_inactive_args {
 */
 {
    struct vnode *vp = ap->a_vp;
-#if __FreeBSD_version < 1000000
-   struct thread *td = ap->a_td;
-#endif
 
    vp->v_object = NULL;
 
@@ -1367,11 +1356,7 @@ struct vop_inactive_args {
     * If this is the last reference, then free up the vnode so as not to
     * tie up the lower vnode.
     */
-#if __FreeBSD_version < 1000000
-    vrecycle(vp, td);
-#else
    vrecycle(vp);
-#endif
    return 0;
 }
 

--- a/open-vm-tools/modules/freebsd/vmmemctl/Makefile
+++ b/open-vm-tools/modules/freebsd/vmmemctl/Makefile
@@ -35,8 +35,7 @@ SRCS    += backdoorGcc32.c
 .endif
 KMOD	= vmmemctl
 PROG    = ../$(KMOD).ko
-NOMAN	= t
-NO_MAN  = t
+MK_MAN  = no
 KLDMOD	= t
 
 # Don't print a warning that the object dir wasn't specified

--- a/open-vm-tools/modules/freebsd/vmmemctl/os.c
+++ b/open-vm-tools/modules/freebsd/vmmemctl/os.c
@@ -89,59 +89,21 @@ typedef struct {
 MALLOC_DEFINE(M_VMMEMCTL, BALLOON_NAME, "vmmemctl metadata");
 
 /*
- * FreeBSD version specific MACROS
+ * FreeBSD specific MACROS
  */
-#if __FreeBSD_version >= 900000
-   #define VM_PAGE_LOCK(page) vm_page_lock(page);
-   #define VM_PAGE_UNLOCK(page) vm_page_unlock(page)
-#else
-   #define VM_PAGE_LOCK(page) vm_page_lock_queues()
-   #define VM_PAGE_UNLOCK(page) vm_page_unlock_queues()
-#endif
+#define VM_PAGE_LOCK(page) vm_page_lock(page);
+#define VM_PAGE_UNLOCK(page) vm_page_unlock(page)
 
-#if __FreeBSD_version > 1000029
-   #define VM_OBJ_LOCK(object) VM_OBJECT_WLOCK(object)
-   #define VM_OBJ_UNLOCK(object) VM_OBJECT_WUNLOCK(object);
-#else
-   #define VM_OBJ_LOCK(object) VM_OBJECT_LOCK(object);
-   #define VM_OBJ_UNLOCK(object) VM_OBJECT_UNLOCK(object);
-#endif
+#define VM_OBJ_LOCK(object) VM_OBJECT_WLOCK(object)
+#define VM_OBJ_UNLOCK(object) VM_OBJECT_WUNLOCK(object);
 
-#if __FreeBSD_version < 1100015
-   #define VM_SYS_PAGES cnt.v_page_count
-#else
-   #define VM_SYS_PAGES vm_cnt.v_page_count
-#endif
+#define VM_SYS_PAGES vm_cnt.v_page_count
 
-/*
- * The kmem_malloc() and kmem_free() APIs changed at different times during
- * the FreeBSD 12.0 ALPHA snapshot releases.  The difference in the
- * __FreeBSD_version values for FreeBSD 12.0 in the following macros are
- * consistent with when each API was changed.
- */
-#if __FreeBSD_version < 1000000
-   #define KVA_ALLOC(size) kmem_alloc_nofault(kernel_map, size)
-   #define KVA_FREE(offset, size) kmem_free(kernel_map, offset, size)
-#else
-   #define KVA_ALLOC(size) kva_alloc(size);
-   #define KVA_FREE(offset, size) kva_free(offset, size)
-#endif
+#define KVA_ALLOC(size) kva_alloc(size);
+#define KVA_FREE(offset, size) kva_free(offset, size)
 
-#if __FreeBSD_version < 1000000
-   #define KMEM_ALLOC(size) kmem_alloc(kernel_map, size)
-#elif  __FreeBSD_version < 1200080
-   #define KMEM_ALLOC(size) kmem_malloc(kernel_arena, size, M_WAITOK | M_ZERO)
-#else
-   #define KMEM_ALLOC(size) kmem_malloc(size, M_WAITOK | M_ZERO)
-#endif
-
-#if __FreeBSD_version < 1000000
-   #define KMEM_FREE(offset, size) kmem_free(kernel_map, offset, size)
-#elif __FreeBSD_version < 1200083
-   #define KMEM_FREE(offset, size) kmem_free(kernel_arena, offset, size)
-#else
-   #define KMEM_FREE(offset, size) kmem_free(offset, size)
-#endif
+#define KMEM_ALLOC(size) kmem_malloc(size, M_WAITOK | M_ZERO)
+#define KMEM_FREE(offset, size) kmem_free(offset, size)
 
 /*
  * Globals


### PR DESCRIPTION
On FreeBSD ports tree we have multiple patches [1] to get open-vm-tools working on all supported versions.  The main idea of this PR is to upstream some of those patches.

While here I decided to also cleanup code that was added to support old FreeBSD versions.  The older supported version is 12.3.

[1] https://github.com/freebsd/freebsd-ports/tree/main/emulators/open-vm-tools/files