### PR TITLE
Fix building containerinfo plugin on i386

### DIFF
--- a/open-vm-tools/services/plugins/containerInfo/containerInfo.c
+++ b/open-vm-tools/services/plugins/containerInfo/containerInfo.c
@@ -608,7 +608,7 @@ ContainerInfoGatherTask(ToolsAppCtx *ctx,   // IN
 
    endInfoGatherTime = g_get_monotonic_time();
 
-   g_info("%s: time to complete containerInfo gather = %ld us\n",
+   g_info("%s: time to complete containerInfo gather = %" G_GINT64_FORMAT "us\n",
           __FUNCTION__, endInfoGatherTime - startInfoGatherTime);
 
 exit:


### PR DESCRIPTION
long is not a gint64 on i386.