### PR TITLE
udev rule to increase io timeout for VMware NVMe 

### DIFF
--- a/open-vm-tools/udev/99-vmware-nvme-udev.rules
+++ b/open-vm-tools/udev/99-vmware-nvme-udev.rules
@@ -1,4 +1,4 @@
 # This file is part of open-vm-tools
 # IO timeout for NVMe
 
-ACTION=="add", SUBSYSTEMS=="block", ATTRS{model}=="VMware Virtual NVMe Disk", RUN+="/bin/sh -c 'echo 180000 >/sys$env{DEVPATH}/device/timeout'"
+ACTION=="add", SUBSYSTEMS=="block", ATTRS{model}=="VMware Virtual NVMe Disk", RUN+="/bin/sh -c 'echo 180000 >/sys$env{DEVPATH}/queue/io_timeout'"

--- a/open-vm-tools/udev/99-vmware-nvme-udev.rules
+++ b/open-vm-tools/udev/99-vmware-nvme-udev.rules
@@ -1,0 +1,4 @@
+# This file is part of open-vm-tools
+# IO timeout for NVMe
+
+ACTION=="add", SUBSYSTEMS=="block", ATTRS{model}=="VMware Virtual NVMe Disk", RUN+="/bin/sh -c 'echo 180000 >/sys$env{DEVPATH}/device/timeout'"


### PR DESCRIPTION
Currenlty open-vm-tools does not contain a udev rule to increase the device timeout for VMware NVMe devices as it does for VMware SCSI devices. Add new udev rule to configure increase the device timeout for VMware NVMe device(s) as already existing for VMware SCSI device(s).

Signed-off-by: Jon Magrini <jmagrini@redhat.com>