### PR TITLE
Detect the proto files for containerd grpc client on SUSE like systems

### DIFF
--- a/open-vm-tools/configure.ac
+++ b/open-vm-tools/configure.ac
@@ -726,10 +726,16 @@ AC_DEFUN([AC_VMW_CONTAINERINFO_MSG],[
 #
 # proto files needed by containerd grpc client.
 #
-   shared_prefix=/usr/share/gocode/src/github.com
+   for d in /usr/share/gocode/src /usr/share/go/1.*/contrib/src; do
+       if test -d "$d"/github.com; then
+           src_prefix="$d"
+           break
+       fi
+   done
+   shared_prefix=$src_prefix/github.com
    AC_SUBST(TYPES_DIR, github.com/containerd/containerd/api/types)
    AC_SUBST(TASKS_PROTOPATH, $shared_prefix/containerd/containerd/api/services/tasks/v1)
-   AC_SUBST(DEP_PROTOPATH, /usr/share/gocode/src)
+   AC_SUBST(DEP_PROTOPATH, $src_prefix)
    AC_SUBST(CONTAINERD_PROTOPATH, $shared_prefix/containerd/containerd/api/services/containers/v1)
    AC_SUBST(GOGO_PROTOPATH, $shared_prefix/gogo/protobuf)
    AC_CHECK_FILE([${CONTAINERD_PROTOPATH}/containers.proto],


### PR DESCRIPTION
On SUSE systems the gosrc'es are installed in a different location, namely /usr/share/go/1.18/contrib/src. Extend the config checks to detect that location also