### PR TITLE
add antrea and calico interface to GUESTINFO_DEFAULT_IFACE_EXCLUDES

### DIFF
--- a/open-vm-tools/services/plugins/guestInfo/guestInfoServer.c
+++ b/open-vm-tools/services/plugins/guestInfo/guestInfoServer.c
@@ -93,7 +93,7 @@ VM_EMBED_VERSION(VMTOOLSD_VERSION_STRING);
 #if defined(_WIN32)
 #define GUESTINFO_DEFAULT_IFACE_EXCLUDES "vEthernet*"
 #else
-#define GUESTINFO_DEFAULT_IFACE_EXCLUDES "docker*,veth*,virbr*"
+#define GUESTINFO_DEFAULT_IFACE_EXCLUDES "docker*,veth*,virbr*,antrea-*,cali*"
 #endif
 
 /*

--- a/open-vm-tools/tools.conf
+++ b/open-vm-tools/tools.conf
@@ -232,7 +232,7 @@
 # Set a comma separated list of network interface names that shall be ignored.
 # Interface names can use wildcards like '*' and '?'.
 # Default for Linux and all non-Windows:
-#exclude-nics=veth*,docker*,virbr*
+#exclude-nics=veth*,docker*,virbr*,antrea-*,cali*
 # Default for Windows:
 #exclude-nics=vEthernet*
 


### PR DESCRIPTION
Fix #https://github.com/vmware/open-vm-tools/issues/638
Add calico and antrea interface pattern to GUESTINFO_DEFAULT_IFACE_EXCLUDES