### PR TITLE
chore: Revise settings for `vmware-user.desktop`

### DIFF
--- a/open-vm-tools/vmware-user-suid-wrapper/vmware-user.desktop.in
+++ b/open-vm-tools/vmware-user-suid-wrapper/vmware-user.desktop.in
@@ -1,9 +1,6 @@
 [Desktop Entry]
 Type=Application
-Encoding=UTF-8
 Exec=_bindir_/vmware-user-suid-wrapper
 Name=VMware User Agent
-# KDE bug 190522: KDE does not autostart items with NoDisplay=true...
-# NoDisplay=true
+NoDisplay=true
 X-KDE-autostart-phase=1
-


### PR DESCRIPTION
This file has barely been touched since 2009, a little maintenance is warranted:
- The [`Encoding` key is deprecated](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#deprecated-items), drop it.
- The [referenced bug for `NoDisplay=true`](https://bugs.kde.org/show_bug.cgi?id=190522) was closed long ago (2012).