### PR TITLE
fix: Reliably start `vmware-user-suid-wrapper`

### DIFF
--- a/open-vm-tools/vmware-user-suid-wrapper/systemd/user/app-vmware-user.service
+++ b/open-vm-tools/vmware-user-suid-wrapper/systemd/user/app-vmware-user.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Open Virtual Machine Tools (vmware-user)
+Documentation=https://github.com/vmware/open-vm-tools
+ConditionVirtualization=vmware
+PartOf=graphical-session.target
+After=graphical-session.target
+
+[Service]
+Type=forking
+ExecStart=/usr/bin/vmware-user-suid-wrapper
+Slice=app.slice
+
+[Install]
+WantedBy=graphical-session.target

--- a/open-vm-tools/vmware-user-suid-wrapper/vmware-user.desktop.in
+++ b/open-vm-tools/vmware-user-suid-wrapper/vmware-user.desktop.in
@@ -6,4 +6,6 @@ Name=VMware User Agent
 # KDE bug 190522: KDE does not autostart items with NoDisplay=true...
 # NoDisplay=true
 X-KDE-autostart-phase=1
-
+# Prevent processing via systemd-xdg-autostart-generator: https://systemd.io/DESKTOP_ENVIRONMENTS/#xdg-autostart-integration
+# Correct service config provided by app-vmware-user.service
+X-systemd-skip=true


### PR DESCRIPTION
When the system manages XDG autostart `.desktop` files via systemd-xdg-autostart-generator, the generated service for `vmware-user.desktop` frequently times out, failing to initialize.

A custom key can be included in the `.desktop` file which systemd will recognize to ignore generating a service config file.

An explicit service config can then be enabled that follows the [convention guidelines for XDG DE Integration](https://systemd.io/DESKTOP_ENVIRONMENTS/#xdg-standardization-for-applications). It should be placed in `/usr/lib/systemd/user/`.