### PR TITLE
Update shutdown code to work for Bottlerocket

### DIFF
--- a/open-vm-tools/lib/system/Makefile.am
+++ b/open-vm-tools/lib/system/Makefile.am
@@ -17,5 +17,8 @@
 
 noinst_LTLIBRARIES = libSystem.la
 
+libSystem_la_CPPFLAGS =
+libSystem_la_CPPFLAGS += @GLIB2_CPPFLAGS@
+
 libSystem_la_SOURCES =
 libSystem_la_SOURCES += systemLinux.c


### PR DESCRIPTION
[Bottlerocket](https://github.com/bottlerocket-os/bottlerocket) doesn't have `/bin/sh` which makes the call `system()` fail with an unexpected error code. This results in the guest shutdown and reboot calls via vmtoolsd returning as if the request was successful but the call actually failed completely. This commit replaces the current call to `system()` with `g_spawn_command_line_sync()` which should be a drop in replacement for `system()`. This removes the dependency on `/bin/sh` but should otherwise remain the same. 

See https://github.com/bottlerocket-os/bottlerocket/pull/3180 where I worked on add this patch for Bottlerocket, it would be great to get this accepted in open-vm-tools so that any OS that also doesn't provide a working `/bin/sh` would also work with these shutdown|reboot calls.