### PR TITLE
chore: Resolve warning `gtk_disable_setlocale() must be called before gtk_init()`

### DIFF
--- a/open-vm-tools/services/plugins/desktopEvents/x11Lock.c
+++ b/open-vm-tools/services/plugins/desktopEvents/x11Lock.c
@@ -421,6 +421,8 @@ X11Lock_Init(ToolsAppCtx *ctx,
    gdk_set_allowed_backends("x11");
 #endif
    /* XXX: is calling gtk_init() multiple times safe? */
+   /* gtk_disable_setlocale() must be called before gtk_init() */
+   gtk_disable_setlocale();
    gtk_init(&argc, (char ***) &argv);
 
    if (!AcquireDisplayLock()) {


### PR DESCRIPTION
## Description

A warning is logged advising to explicitly opt-out of GTK setting the locale. This is relevant when you manage locale setting yourself (_like `open-vm-tools` appears to_):

```console
# Generated service from `vmware-user.desktop` by `systemd-xdg-autostart-generator`:
$ systemctl --user status "app-vmware\x2duser@autostart.service"
vmtoolsd[947]: gtk_disable_setlocale() must be called before gtk_init()

# CLI command:
$ vmtoolsd -n vmusr --blockFd 3
Gtk-WARNING **: 17:53:50.082: gtk_disable_setlocale() must be called before gtk_init()
```

### Reasoning

[GTK docs `gtk_disable_setlocale()`](https://docs.gtk.org/gtk3/func.disable_setlocale.html):

> _Prevents `gtk_init()`, `gtk_init_check()`, `gtk_init_with_args()` and `gtk_parse_args()` from automatically calling `setlocale(LC_ALL, "")`._
> _You would want to use this function if you wanted to set the locale for your program to something other than the user’s locale, or if you wanted to set different values for different locale categories._
> 
> _Most programs should not need to call this function._

A grep for `locale` shows quite a bit of explicit handling by `open-vm-tools` codebase, including setting `setlocale(LC_ALL, "")` itself. Here's an example for `vmtoolsd`:

https://github.com/vmware/open-vm-tools/blob/ed34acd62f67aceace5f28d214dc8e47b6e35691/open-vm-tools/services/vmtoolsd/mainPosix.c#L196

**NOTE:** I've not compiled this change to verify. I've just seen it present over the years and thought I'd look into it and provide a PR that should resolve it. There is no harm with ignoring the warning AFAIK, the PR would just resolve some log noise that I've seen contribute some confusion to users that notice it while troubleshooting.