### PR TITLE
Fix build failures about json-c's debug.h

### DIFF
--- a/open-vm-tools/services/plugins/dndcp/Makefile.am
+++ b/open-vm-tools/services/plugins/dndcp/Makefile.am
@@ -21,6 +21,7 @@ plugindir = @VMUSR_PLUGIN_INSTALLDIR@
 plugin_LTLIBRARIES = libdndcp.la
 
 libdndcp_la_CPPFLAGS =
+libdndcp_la_CPPFLAGS += -I$(top_srcdir)/lib/include
 libdndcp_la_CPPFLAGS += @GTK_CPPFLAGS@
 libdndcp_la_CPPFLAGS += @PLUGIN_CPPFLAGS@
 libdndcp_la_CPPFLAGS += -I$(top_srcdir)/services/plugins/dndcp/dnd
@@ -28,7 +29,6 @@ libdndcp_la_CPPFLAGS += -I$(top_srcdir)/services/plugins/dndcp/dndGuest
 libdndcp_la_CPPFLAGS += -I$(top_srcdir)/services/plugins/dndcp/dndGuestBase
 libdndcp_la_CPPFLAGS += -I$(top_srcdir)/services/plugins/dndcp/stringxx
 libdndcp_la_CPPFLAGS += -I$(top_srcdir)/services/plugins/dndcp/xutils
-libdndcp_la_CPPFLAGS += -I$(top_srcdir)/include
 libdndcp_la_CPPFLAGS += @XDR_CPPFLAGS@
 
 # Passing C++ related flags to CPPFLAGS generates error.


### PR DESCRIPTION
open-vm-tools currently fails to build on certain system setup due to conflicting header filename (debug.h). The errors look like:

```
copyPasteUIX11.h: In member function 'void CopyPasteUIX11::SetBlockControl(DnDBlockControl*)':                                                                                                                                                                                     
copyPasteUIX11.h:90:9: error: 'Debug' was not declared in this scope; did you mean 'g_debug'?                                                                                                                                                                                      
   90 |       { Debug("Setting mBlockCtrl to %p\n", blockCtrl);                                                                                                                                                                                                                    
      |         ^~~~~                                                                                                                                                                                                                                                              
      |         g_debug                                        
```

This is because when util-linux's configured with cryptsetup support, a dependency chain brings in json-c's include path into GTK_CPPFLAGS and there's `/usr/include/json-c/debug.h` with the same filename.

```
gdk-pixbuf-xlib-2.0 -> gdk-pixbuf-2.0 -> gio-2.0 -> mount -> libcryptsetup -> json-c
```

Preferring our include path over GTK_CPPFLAGS fixes building here.