### PR TITLE
Ensure that scriptFile is a file

### DIFF
--- a/open-vm-tools/scripts/common/statechange.sh
+++ b/open-vm-tools/scripts/common/statechange.sh
@@ -88,7 +88,7 @@ RunScripts() {
 
    if [ -d "$scriptDir" ]; then
       for scriptFile in "$scriptDir"/*; do
-         if [ -x "$scriptFile" ]; then
+         if [ -x "$scriptFile" -a -f "$scriptFile" ]; then
             "$scriptFile" $powerOp
             exitCode=`expr $exitCode \| $?`
          fi


### PR DESCRIPTION
If the scripts directory contained a directory, for example __pycache__
it would try to execute it. This ensures that we only execute files.