### PR TITLE
Updated NetworkManager calls in suspend/resume scripts.

### DIFF
--- a/open-vm-tools/scripts/linux/network
+++ b/open-vm-tools/scripts/linux/network
@@ -529,20 +529,20 @@ TranquilizeNetworkManager()
          ;;
    esac
 
-   # NetworkManager 0.8.0 and above
-   $dbusSend --system --print-reply          \
-      --dest=org.freedesktop.NetworkManager  \
-      /org/freedesktop/NetworkManager        \
-      org.freedesktop.NetworkManager.Enable boolean:false
-   rc=$?
-   if [ $rc -eq 0 ]; then
-      return $rc
-   fi
-   # NetworkManager 0.7.0
+   # NetworkManager 0.9.1 and above
    $dbusSend --system --print-reply          \
       --dest=org.freedesktop.NetworkManager  \
       /org/freedesktop/NetworkManager        \
       org.freedesktop.NetworkManager.Sleep boolean:true
+   rc=$?
+   if [ $rc -eq 0 ]; then
+      return $rc
+   fi
+   # NetworkManager 0.9.0
+   $dbusSend --system --print-reply          \
+      --dest=org.freedesktop.NetworkManager  \
+      /org/freedesktop/NetworkManager        \
+      org.freedesktop.NetworkManager.Enable boolean:false
    rc=$?
    if [ $rc -eq 0 ]; then
       return $rc
@@ -578,20 +578,20 @@ WakeNetworkManager()
    dbusSend=`which dbus-send 2>/dev/null`
    rc=$?
    if [ $rc = 0 ]; then
-      # NetworkManager 0.8.0
-      $dbusSend --system --print-reply          \
-         --dest=org.freedesktop.NetworkManager  \
-         /org/freedesktop/NetworkManager        \
-         org.freedesktop.NetworkManager.Enable boolean:true
-      rc=$?
-      if [ $rc = 0 ]; then
-         return $rc
-      fi
-      # NetworkManager 0.7.0
+      # NetworkManager 0.9.1 and above
       $dbusSend --system --print-reply          \
          --dest=org.freedesktop.NetworkManager  \
          /org/freedesktop/NetworkManager        \
          org.freedesktop.NetworkManager.Sleep boolean:false
+      rc=$?
+      if [ $rc = 0 ]; then
+         return $rc
+      fi
+      # NetworkManager 0.9.0
+      $dbusSend --system --print-reply          \
+         --dest=org.freedesktop.NetworkManager  \
+         /org/freedesktop/NetworkManager        \
+         org.freedesktop.NetworkManager.Enable boolean:true
       rc=$?
       if [ $rc = 0 ]; then
          return $rc


### PR DESCRIPTION
The org.freedesktop.NetworkManager.Enable method used by the suspend/resume scripts changes the NetworkEnabled state in NM, which is persisted to disk in the state file (typically at `/var/lib/NetworkManager/NetworkManager.state`).

If the resume script fails for any reason at all, the system will be left with NetworkManager in a disabled state, where the service is running, but all interfaces are ignored by NM, and most GUI interfaces will show the network as simply disappeared, as opposed to indicating it is _disabled_. 

This code was added in commit 13ab4cc0a376993ac8b946a3a1f22126a4a36635, which indicates that Enabled is tried first due to a bug in NM 0.9 on Ubuntu 11.10. I have confirmed that at least NM 0.9.1 on Ubuntu 11.10 correctly responds to Sleep, and several modern Linux distributions with modern copies of NM appear to respond correctly.

Use of the Sleep method is preferred, as the change does not persist a cold (re)boot, and avoids potentially leaving the system in state that's confusing to users.

I believe this to be the cause of a problem I've recently encountered, as well as a possible culprit of #426, along with many reports of similar problems across the web. A Google search for `vmware "nmcli networking on"` or just `"nmcli networking on"` shows many reports where networking "disappears" from guests, where the nmcli command is able to "fix" the problem.

With the exception of the nmcli tool itself, this network script appears to be the only widespread user of the Enabled dbus method. Outside of manually editing the state file, this is the only way to toggle the NetworkEnabled state, which is not really represented in the UI, especially in GUI frontends for NetworkManager.  Since nothing else will ever toggle the NetworkEnabled state _automatically_, I believe the issue has to be the resume script not running for whatever reason, and leaving NM disabled.