### PR TITLE
sizeof('c')=4, not 1: fix read-past-the-end/overallocation

### DIFF
--- a/open-vm-tools/lib/hgfsServer/hgfsServer.c
+++ b/open-vm-tools/lib/hgfsServer/hgfsServer.c
@@ -9566,7 +9566,7 @@ HgfsServerGetTargetRelativePath(const char* source,    // IN: source file name
     * to the relative target path.
     */
 
-   targetSize = level * HGFS_PARENT_DIR_LEN + strlen(relativeTarget) + sizeof '\0';
+   targetSize = level * HGFS_PARENT_DIR_LEN + strlen(relativeTarget) + 1 /* NUL */;
    result = malloc(targetSize);
    currentPosition = result;
    if (result != NULL) {
@@ -9575,7 +9575,7 @@ HgfsServerGetTargetRelativePath(const char* source,    // IN: source file name
          level--;
          currentPosition += HGFS_PARENT_DIR_LEN;
       }
-      memcpy(currentPosition, relativeTarget, strlen(relativeTarget) + sizeof '\0');
+      memcpy(currentPosition, relativeTarget, strlen(relativeTarget) + 1 /* NUL */);
    }
    return result;
 }


### PR DESCRIPTION
As found by DCS: `[^._]sizeof[ (]'.{1,2}' filetype:c`

Ref: https://paste.sr.ht/~nabijaczleweli/6ee9ccf301a2651afb693bff46e3671d3f7cdd89
Ref: https://101010.pl/@nabijaczleweli/111587138076843793