### PR TITLE
fix(scripts): don't hardcode vmsupportdir, follow $(bindir)

### DIFF
--- a/open-vm-tools/scripts/Makefile.am
+++ b/open-vm-tools/scripts/Makefile.am
@@ -25,7 +25,7 @@ confdir = /etc/vmware-tools
 conf_SCRIPTS = ./common/statechange.subr
 conf_SCRIPTS += $(defaultscripts)
 
-vmsupportdir = /usr/bin
+vmsupportdir = $(bindir)
 
 vmsupport_SCRIPTS = ./common/vm-support
 


### PR DESCRIPTION
Replaces hardcoded `vmsupportdir` value with `$(bindir)`