### PR TITLE
fix(libguestStoreClient): underlinking with icu

### DIFF
--- a/open-vm-tools/libguestStoreClient/Makefile.am
+++ b/open-vm-tools/libguestStoreClient/Makefile.am
@@ -24,6 +24,7 @@ libguestStoreClient_la_LIBADD += ../lib/unicode/libUnicode.la
 libguestStoreClient_la_LIBADD += ../lib/misc/libMisc.la
 libguestStoreClient_la_LIBADD += -lpthread
 libguestStoreClient_la_LIBADD += -ldl
+libguestStoreClient_la_LIBADD += @ICU_LIBS@
 
 libguestStoreClient_la_SOURCES =
 libguestStoreClient_la_SOURCES += guestStoreClientLib.c


### PR DESCRIPTION
When enabling icu, libguestStoreClient is failing to compile due to missing link with icu :

```
make[1]: Leaving directory '/var/tmp/paludis/build/app-virtualization-open-vm-tools-12.4.5/work/open-vm-tools-stable-12.4.5/open-vm-tools/libguestStoreClient'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: ../lib/unicode/.libs/libUnicode.a(unicodeICU.o): in function `Unicode_CompareWithLocale':
unicodeICU.c:(.text+0x3a): undefined reference to `uiter_setUTF8_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: unicodeICU.c:(.text+0x4a): undefined reference to `uiter_setUTF8_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: unicodeICU.c:(.text+0x63): undefined reference to `ucol_open_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: unicodeICU.c:(.text+0x88): undefined reference to `ucol_setAttribute_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: unicodeICU.c:(.text+0x9b): undefined reference to `ucol_setAttribute_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: unicodeICU.c:(.text+0xac): undefined reference to `ucol_strcollIter_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: unicodeICU.c:(.text+0xb6): undefined reference to `ucol_close_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: ../lib/unicode/.libs/libUnicode.a(unicodeICU.o): in function `Unicode_Normalize':
unicodeICU.c:(.text+0x151): undefined reference to `uiter_setUTF8_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: unicodeICU.c:(.text+0x18e): undefined reference to `unorm_next_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: unicodeICU.c:(.text+0x1de): undefined reference to `unorm_next_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: ../lib/unicode/.libs/libUnicode.a(unicodeICU.o): in function `Unicode_ToLower':
unicodeICU.c:(.text+0x291): undefined reference to `ucasemap_open_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: unicodeICU.c:(.text+0x2a4): undefined reference to `ucasemap_close_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: unicodeICU.c:(.text+0x2e3): undefined reference to `ucasemap_utf8ToLower_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: unicodeICU.c:(.text+0x31b): undefined reference to `ucasemap_utf8ToLower_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: ../lib/unicode/.libs/libUnicode.a(unicodeICU.o): in function `Unicode_ToUpper':
unicodeICU.c:(.text+0x381): undefined reference to `ucasemap_open_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: unicodeICU.c:(.text+0x394): undefined reference to `ucasemap_close_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: unicodeICU.c:(.text+0x3d3): undefined reference to `ucasemap_utf8ToUpper_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: unicodeICU.c:(.text+0x40b): undefined reference to `ucasemap_utf8ToUpper_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: ../lib/unicode/.libs/libUnicode.a(unicodeICU.o): in function `Unicode_ToTitle':
unicodeICU.c:(.text+0x471): undefined reference to `ucasemap_open_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: unicodeICU.c:(.text+0x484): undefined reference to `ucasemap_close_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: unicodeICU.c:(.text+0x4c3): undefined reference to `ucasemap_utf8ToTitle_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: unicodeICU.c:(.text+0x4fb): undefined reference to `ucasemap_utf8ToTitle_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: ../lib/misc/.libs/libMisc.a(codeset.o): in function `CodeSet_GenericToGenericDb':
codeset.c:(.text+0x12b): undefined reference to `ucnv_open_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: codeset.c:(.text+0x14c): undefined reference to `ucnv_open_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: codeset.c:(.text+0x181): undefined reference to `UCNV_FROM_U_CALLBACK_STOP_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: codeset.c:(.text+0x188): undefined reference to `UCNV_TO_U_CALLBACK_STOP_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: codeset.c:(.text+0x1a9): undefined reference to `ucnv_setToUCallBack_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: codeset.c:(.text+0x1b9): undefined reference to `ucnv_close_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: codeset.c:(.text+0x1c1): undefined reference to `ucnv_close_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: codeset.c:(.text+0x213): undefined reference to `UCNV_FROM_U_CALLBACK_SUBSTITUTE_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: codeset.c:(.text+0x21a): undefined reference to `UCNV_TO_U_CALLBACK_SUBSTITUTE_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: codeset.c:(.text+0x24d): undefined reference to `ucnv_setFromUCallBack_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: codeset.c:(.text+0x304): undefined reference to `ucnv_convertEx_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: codeset.c:(.text+0x353): undefined reference to `UCNV_FROM_U_CALLBACK_SKIP_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: codeset.c:(.text+0x35a): undefined reference to `UCNV_TO_U_CALLBACK_SKIP_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: codeset.c:(.text+0x374): undefined reference to `ucnv_close_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: codeset.c:(.text+0x39b): undefined reference to `ucnv_close_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: ../lib/misc/.libs/libMisc.a(codeset.o): in function `CodeSet_IsEncodingSupported':
codeset.c:(.text+0x8ce): undefined reference to `ucnv_open_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: codeset.c:(.text+0x8e9): undefined reference to `ucnv_close_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: ../lib/misc/.libs/libMisc.a(codeset.o): in function `CodeSet_Validate':
codeset.c:(.text+0x957): undefined reference to `ucnv_open_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: codeset.c:(.text+0x96d): undefined reference to `UCNV_TO_U_CALLBACK_STOP_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: codeset.c:(.text+0x97f): undefined reference to `ucnv_setToUCallBack_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: codeset.c:(.text+0x9a0): undefined reference to `ucnv_toUChars_74'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: codeset.c:(.text+0x9a8): undefined reference to `ucnv_close_74'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:553: libguestStoreClient.la] Error 1
make: *** [Makefile:560: all-recursive] Error 1
```

[buildlog.txt](https://github.com/user-attachments/files/16452470/buildlog.txt)
