### PR TITLE
Fix xmlsec detection when cross-compiling with pkg-config

### DIFF
--- a/open-vm-tools/configure.ac
+++ b/open-vm-tools/configure.ac
@@ -884,7 +884,7 @@ if test "$enable_vgauth" = "yes" ; then
                      [],
                      [xmlsec/xmlsec.h],
                      [xmlSecCheckVersionExt],
-                     [XMLSEC1_VER=`pkg-config --modversion xmlsec1`
+                     [XMLSEC1_VER=`$PKG_CONFIG --modversion xmlsec1`
                       xmlsec1_major_version="`echo $XMLSEC1_VER | cut -f1 -d. | cut -f1 -d-`"
                       xmlsec1_minor_version="`echo $XMLSEC1_VER | cut -f2 -d. | cut -f1 -d-`"
                       xmlsec1_micro_version="`echo $XMLSEC1_VER | cut -f3 -d. | cut -f1 -d-`"

--- a/open-vm-tools/configure.ac
+++ b/open-vm-tools/configure.ac
@@ -879,7 +879,7 @@ if test "$enable_vgauth" = "yes" ; then
    AC_VMW_DEFAULT_FLAGS([XMLSEC1])
    AC_VMW_CHECK_LIB([xmlsec1],
                      [XMLSEC1],
-                     [],
+                     [xmlsec1],
                      [xmlsec1-config],
                      [],
                      [xmlsec/xmlsec.h],


### PR DESCRIPTION
The `xmlsec1-config` script does not help when cross-compiling. pkg-config is subsequently used for a version detection anyway.

In that version detection, the `$PKG_CONFIG` variable should be respected.