### PR TITLE
Fix build with libc++ 19

### DIFF
--- a/open-vm-tools/services/plugins/dndcp/stringxx/string.hh
+++ b/open-vm-tools/services/plugins/dndcp/stringxx/string.hh
@@ -87,7 +87,7 @@ namespace utf {
  * to replace the std::string in our codebase.
  */
 typedef std::string utf8string;
-typedef std::basic_string<utf16_t> utf16string;
+typedef std::u16string utf16string;
 
 class VMSTRING_EXPORT string
 {


### PR DESCRIPTION
As noted in the libc++ 19 release notes [1], std::char_traits<> is now
only provided for char, char8_t, char16_t, char32_t and wchar_t, and any
instantiation for other types will fail.

This causes emulators/open-vm-tools to fail to compile with clang 19 and
libc++ 19.

This can be fixed by using the standard type std::u16string for UTF-16
strings, instead of (effectively) std::basic_string<uint16_t>.

[1] https://libcxx.llvm.org/ReleaseNotes/19.html#deprecations-and-removals
