### PR TITLE
glib_stubs: avoid GLib g_free macro redefinition error

### DIFF
--- a/open-vm-tools/lib/rpcChannel/glib_stubs.c
+++ b/open-vm-tools/lib/rpcChannel/glib_stubs.c
@@ -35,6 +35,9 @@
 
 void *g_malloc0(size_t s) { return Util_SafeCalloc(1, s); }
 void *g_malloc0_n(size_t n, size_t s) { return Util_SafeCalloc(n, s); }
+/* GLib defines g_free as a macro, so undefine it before providing
+ * our own stub implementation. */
+#undef g_free
 void g_free(void *p) { free(p); }
 
 void g_mutex_init(GMutex *mutex) { }


### PR DESCRIPTION
glib 2.78+ defines g_free as an object-size checking macro. open-vm-tools overrides g_free(), leading to preprocessor expansion inside the function signature and breaking the build.

Undefine the macro before defining the stub.

Upstream-Status: Pending