### PR TITLE
vmhgfs-fuse: invalidate attribute cache on open(O_TRUNC)

### DIFF
--- a/open-vm-tools/vmhgfs-fuse/main.c
+++ b/open-vm-tools/vmhgfs-fuse/main.c
@@ -1038,6 +1038,16 @@ hgfs_open(const char *path,          //IN: path to a file
 
    res = HgfsOpen(abspath, fi);
 
+   /*
+    * When the open carried O_TRUNC the server truncated the file, but the
+    * cached attributes still carry the pre-truncate size. Drop them, or a
+    * subsequent append is positioned at the stale offset and leaves a hole
+    * of NUL bytes at the start of the file.
+    */
+   if (res == 0 && (fi->flags & O_TRUNC) != 0) {
+      HgfsInvalidateAttrCache(abspath);
+   }
+
 exit:
    LOG(4, ("Exit(%d)\n", res));
    freeAbsPath(abspath);


### PR DESCRIPTION
## Root cause

`hgfs_open()` lets the HGFS server truncate the file as part of the open request
(`HgfsGetOpenFlags()` maps `O_TRUNC` to `HGFS_OPEN_EMPTY` / `HGFS_OPEN_CREATE_EMPTY`),
but it never touches the client-side attribute cache. The size cached by
`HgfsSetAttrCache()` therefore keeps its pre-truncate value for up to
`HGFS_DEFAULT_TTL` — one second (`vmhgfs-fuse/cache.c:34`, `lib/include/hgfsDevLinux.h:52`).

A process that reopens the file with `O_APPEND` inside that window gets the stale size
back from `lseek(SEEK_END)` and writes past the end of the already truncated file,
leaving a hole of NUL bytes at the start.

`hgfs_open()` is the only callback that changes a file and leaves the cache alone:
`hgfs_unlink()`, `hgfs_rmdir()`, `hgfs_rename()` and `hgfs_write()` call
`HgfsInvalidateAttrCache()`, and `hgfs_truncate()` refreshes it via `HgfsSetAttrCache()`.

## Reproducer

```python
import os
p = '/mnt/hgfs/share/probe'                 # any file on a shared folder
open(p, 'wb').write(b'A' * 236)
os.stat(p)                                  # warm the attribute cache
fd = os.open(p, os.O_WRONLY | os.O_TRUNC); os.close(fd)
fd = os.open(p, os.O_WRONLY | os.O_APPEND)
print(os.lseek(fd, 0, os.SEEK_END))         # 236 -> stale, 0 -> correct
```

Prints `236` on a shared folder, `0` on ext4/tmpfs. What narrows it down to the client:

* mounting with `-o attr_timeout=0` makes it fail *every* time, so the stale size comes
  from the daemon, not from the kernel attribute cache;
* the same file read through a *second* mount of the same share reports `0`, so the host
  truncated it correctly;
* `ftruncate()` instead of `O_TRUNC` is fine — that path goes through `hgfs_truncate()`;
* a 1.5 s pause between the truncate and the append is fine — the TTL has expired;
* reproduces regardless of kernel (6.x/7.0), of open-vm-tools version (13.0.0 and
  13.0.10 behave identically, and `vmhgfs-fuse` is unchanged in `stable-13.1.0`).

## Why it matters in practice

`git fetch` walks straight into the window. It truncates `.git/FETCH_HEAD` at the start
and appends to it from a child process about 1.5 s later:

```
18:04:32.150 openat(".git/FETCH_HEAD", O_WRONLY|O_CREAT|O_TRUNC) = 3
18:04:33.632 openat(".git/FETCH_HEAD", O_WRONLY|O_CREAT|O_APPEND) = 3   [child]
18:04:33.632 lseek(3, 0, SEEK_END) = 732                                 ← should be 0
18:04:33.737 write(3, "8ca81430f3f40c9f...", 244) = 244
```

`FETCH_HEAD` ends up starting with NUL bytes and doubling in size on every fetch, and
`git pull` fails with:

```
Your configuration specifies to merge with the ref 'refs/heads/master'
from the remote, but no such ref was fetched.
```

This is the mechanism behind #90, reported in 2016 as "git index corruption and Bus
Error crashes" and still open.

## The fix

Invalidate the cached attributes when the open carried `O_TRUNC`.

## Verification

Built as a patched `open-vm-tools` package (13.0.10) and installed on Ubuntu 26.04,
kernel 7.0.0-29, VMware Workstation host, shared folder mounted via `/etc/fstab`:

| check | stock | patched |
|---|---|---|
| reproducer above | `lseek` returns 236 | returns 0 |
| five `git fetch` in a row | 236 → 472 → 708 → 944 → 1180 bytes | 236 bytes every time |
| `git pull` three times in a row | fails on the second one | up to date, three times |

Fixes #90
